### PR TITLE
🎨 Palette: Improve LoadingButton accessibility and interaction states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-10-24 - Accessible Icon Props and Loading Button State
+**Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
+**Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/src/components/Icon.svelte
+++ b/src/components/Icon.svelte
@@ -19,7 +19,7 @@
 	export { key as icon, align, width, height, color };
 </script>
 
-<Icon class={alignClass} {icon} {height} {width} {color} />
+<Icon class={alignClass} {icon} {height} {width} {color} {...$$restProps} />
 
 <style>
 	:global(.align-icon-right) {

--- a/src/components/LoadingButton.svelte
+++ b/src/components/LoadingButton.svelte
@@ -4,6 +4,7 @@
 	import Button, { Label } from '@smui/button';
 	import Icon from 'src/components/Icon.svelte';
 	import CircularProgress from '@smui/circular-progress';
+	import { onDestroy } from 'svelte';
 
 	let className = '';
 	export { className as class };
@@ -24,10 +25,16 @@
 
 	let loading: boolean | undefined;
 	let hasError = false;
+	let resetTimeout: ReturnType<typeof setTimeout>;
+
+	onDestroy(() => {
+		clearTimeout(resetTimeout);
+	});
 
 	async function handleClick() {
 		if (loading) return;
 
+		hasError = false;
 		loading = true;
 
 		try {
@@ -38,19 +45,26 @@
 		}
 
 		loading = false;
+
+		if (!hasError) {
+			clearTimeout(resetTimeout);
+			resetTimeout = setTimeout(() => {
+				loading = undefined;
+			}, 3000);
+		}
 	}
 </script>
 
 <Button class={className} disabled={isDisabled} on:click={handleClick} {variant}>
 	<Label><slot /></Label>
 	{#if loading}
-		<div class="loading">
+		<div class="loading" role="status" aria-label="Loading">
 			<CircularProgress style="height: 20px; width: 20px;" indeterminate />
 		</div>
 	{:else if hasError}
-		<Icon icon="error" align="right" />
+		<Icon icon="error" align="right" aria-label="Error" />
 	{:else if loading === false}
-		<Icon icon="done" align="right"/>
+		<Icon icon="done" align="right" aria-label="Success" />
 	{/if}
 </Button>
 


### PR DESCRIPTION
💡 What:
- Updated `Icon.svelte` to support spreading props (`{...$$restProps}`), enabling accessibility attributes like `aria-label` to be passed down.
- Updated `LoadingButton.svelte` to reset "Success" state after 3 seconds, preventing persistent checkmarks.
- Fixed a bug in `LoadingButton.svelte` where error state persisted incorrectly on retry.
- Added `aria-label` to loading spinner and success/error icons for screen readers.

🎯 Why:
- Users were confused by "Success" checkmarks that never disappeared.
- Screen readers had no context for "Loading", "Success", or "Error" states (just an icon change).
- Retry logic was flawed, showing error icon even during retry.

📸 Verification:
- Verified visually and via Playwright script that states transition correctly and accessibility labels are present.
- Ran `yarn run check`, `yarn lint`, and `yarn build`.

♿ Accessibility:
- Added `role="status"` and `aria-label="Loading"` to loading indicator.
- Added accessible names to status icons.

---
*PR created automatically by Jules for task [12791979761042954505](https://jules.google.com/task/12791979761042954505) started by @Yeboster*