### PR TITLE
⚡ Bolt: Optimize domain search debouncing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,8 @@
 
 **Learning:** Asynchronous typeahead searches must implement a request ID mechanism. Without it, stale responses can overwrite newer ones, leading to correct search terms displaying incorrect results.
 **Action:** Always use a request ID or cancellation token pattern when implementing async search/filter operations.
+
+## 2024-10-25 - Svelte Input Debouncing
+
+**Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
+**Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.

--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -22,10 +22,13 @@
 	$: invalid = domainName !== '' && !validator.validate(domainName, { raiseError: false });
 	$: nameSearchedLabel = nameSearched ? `${nameSearched}.${$metaNamesSdk.config.tld}` : null;
 
-	function debounce() {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	function debounce(_domainName: string) {
 		clearTimeout(debounceTimer);
 		debounceTimer = setTimeout(async () => await search(), 400);
 	}
+
+	$: debounce(domainName);
 
 	async function search(submit = false) {
 		if (invalid) return;
@@ -60,7 +63,6 @@
 			class="domain-input"
 			variant="outlined"
 			bind:value={domainName}
-			on:keyup={() => debounce()}
 			bind:invalid
 			label="Domain name"
 			withTrailingIcon


### PR DESCRIPTION
💡 What: Replaced `on:keyup` event handler for domain search with a reactive statement `$: debounce(domainName)`.
🎯 Why: The previous implementation triggered a search debounce on every keyup event, including navigation keys (arrows, Shift, Ctrl) which don't change the search term. This resulted in unnecessary API calls and potential race conditions if the user was just moving the cursor. It also potentially missed changes from paste/cut if keyup wasn't triggered.
📊 Impact: Eliminates API calls for navigation actions within the search input. Ensures search is triggered for all input methods (typing, pasting, dragging).
🔬 Measurement: Verified by observing that typing triggers search, but navigating with arrow keys does not (since `domainName` value doesn't change). Confirmed with Playwright test that the input remains interactive and functional.

---
*PR created automatically by Jules for task [1433100531025115758](https://jules.google.com/task/1433100531025115758) started by @yeboster*