### PR TITLE
🎨 Palette: Add loading spinner to domain search

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -70,9 +70,21 @@
 		>
 			<svelte:fragment slot="trailingIcon">
 				<div class="submit">
-					<IconButton aria-label="search">
-						<Icon icon="search" />
-					</IconButton>
+					{#if isLoading}
+						<div
+							style="display: flex; align-items: center; justify-content: center; width: 48px; height: 48px;"
+						>
+							<CircularProgress
+								style="height: 24px; width: 24px;"
+								indeterminate
+								aria-label="Searching..."
+							/>
+						</div>
+					{:else}
+						<IconButton aria-label="search" on:click={submit}>
+							<Icon icon="search" />
+						</IconButton>
+					{/if}
 				</div>
 			</svelte:fragment>
 			<svelte:fragment slot="helper">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
 		}),
 		sveltekit(),
 		nodePolyfills({
-			include: ['buffer', 'crypto', 'stream']
+			include: ['buffer', 'crypto', 'stream', 'util']
 		}),
 		tsconfigPaths()
 	],


### PR DESCRIPTION
* 💡 What: Replaced the search icon with a loading spinner during domain search in `DomainSearch.svelte`.
* 🎯 Why: To provide immediate visual feedback that the application is processing the search request.
* ♿ Accessibility: Added `aria-label="Searching..."` to the spinner for screen readers.
* 🛠️ Fix: Added `util` to `vite-plugin-node-polyfills` include list in `vite.config.ts` to fix `Cannot access "util.debuglog"` runtime error.

---
*PR created automatically by Jules for task [2045003591936041737](https://jules.google.com/task/2045003591936041737) started by @yeboster*