### PR TITLE
🎨 Palette: Add loading spinner to domain search input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -69,11 +69,17 @@
 			autofocus
 		>
 			<svelte:fragment slot="trailingIcon">
-				<div class="submit">
-					<IconButton aria-label="search">
-						<Icon icon="search" />
-					</IconButton>
-				</div>
+				{#if isLoading}
+					<div class="loading-spinner" role="status" aria-label="Searching...">
+						<CircularProgress style="height: 24px; width: 24px;" indeterminate />
+					</div>
+				{:else}
+					<div class="submit">
+						<IconButton aria-label="search">
+							<Icon icon="search" />
+						</IconButton>
+					</div>
+				{/if}
 			</svelte:fragment>
 			<svelte:fragment slot="helper">
 				{#if errors.length > 0}
@@ -177,6 +183,15 @@
 	}
 
 	.submit {
+		align-self: center;
+	}
+
+	.loading-spinner {
+		width: 48px;
+		height: 48px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
 		align-self: center;
 	}
 </style>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
 		}),
 		sveltekit(),
 		nodePolyfills({
-			include: ['buffer', 'crypto', 'stream']
+			include: ['buffer', 'crypto', 'stream', 'util']
 		}),
 		tsconfigPaths()
 	],


### PR DESCRIPTION
💡 What: Added a loading spinner to the domain search input field, replacing the search icon when a search is in progress.
🎯 Why: To provide immediate visual feedback to the user that their input is being processed, improving the perceived responsiveness.
♿ Accessibility: Added role="status" and aria-label="Searching..." to the spinner container.
🔧 Fix: Added "util" to nodePolyfills in vite.config.ts to resolve runtime errors.

---
*PR created automatically by Jules for task [347885244364555084](https://jules.google.com/task/347885244364555084) started by @yeboster*