### PR TITLE
🎨 Palette: Fix Dialog ARIA attributes and unique IDs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/src/components/Record.svelte
+++ b/src/components/Record.svelte
@@ -29,6 +29,7 @@
 	$: disabled = !edit;
 	$: validator = getValidator(klass);
 	$: maxLength = 'maxLength' in validator.rules ? (validator.rules['maxLength'] as number) : 64;
+	$: dialogId = klass.toLowerCase().replace(/\s+/g, '-');
 
 	let edit = false;
 
@@ -55,13 +56,15 @@
 <div class="record-container {editMode ? 'edit' : ''}">
 	<Dialog
 		bind:open={dialogOpen}
-		aria-labelledby="confirmation-title"
-		aria-describedby="confirmation-content"
+		aria-labelledby={`confirmation-title-${dialogId}`}
+		aria-describedby={`confirmation-content-${dialogId}`}
 	>
-		<Title id="simple-title">Confirm action</Title>
-		<Content id="simple-content">Do you really want to remove the record?</Content>
+		<Title id={`confirmation-title-${dialogId}`}>Confirm action</Title>
+		<Content id={`confirmation-content-${dialogId}`}
+			>Do you really want to remove the record?</Content
+		>
 		<Actions>
-			<Button>
+			<Button action="close">
 				<Label>No</Label>
 			</Button>
 			<Button on:click={destroy}>


### PR DESCRIPTION
This PR fixes an accessibility issue in the `Record` component where the confirmation dialog had hardcoded IDs for its title and content, leading to broken ARIA references and duplicate IDs when multiple records were present.

Changes:
- Dynamic ID generation for Dialog title and content using the `klass` prop.
- Updated `aria-labelledby` and `aria-describedby` to match the generated IDs.
- Added `action="close"` to the cancel button.

Verified with Playwright (temporary script) to confirm correct ARIA attributes are rendered.

---
*PR created automatically by Jules for task [9889740476482371841](https://jules.google.com/task/9889740476482371841) started by @yeboster*