### PR TITLE
🎨 Palette: Add loading spinner to domain search input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,8 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+
+## 2026-02-21 - Immediate Feedback in Typeahead Search
+
+**Learning:** When using debounced search-as-you-type, users may not notice distant loading indicators. Replacing the search icon *inside* the input with a spinner provides immediate, localized confirmation that their input is being processed.
+**Action:** Use a `CircularProgress` or spinner in the `trailingIcon` slot of inputs during async operations, maintaining the same dimensions (e.g., 48x48px) to prevent layout shifts.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -70,9 +70,15 @@
 		>
 			<svelte:fragment slot="trailingIcon">
 				<div class="submit">
-					<IconButton aria-label="search">
-						<Icon icon="search" />
-					</IconButton>
+					{#if isLoading}
+						<div class="loading-icon" role="status" aria-label="Searching">
+							<CircularProgress style="height: 24px; width: 24px;" indeterminate />
+						</div>
+					{:else}
+						<IconButton aria-label="search">
+							<Icon icon="search" />
+						</IconButton>
+					{/if}
 				</div>
 			</svelte:fragment>
 			<svelte:fragment slot="helper">
@@ -178,5 +184,13 @@
 
 	.submit {
 		align-self: center;
+	}
+
+	.loading-icon {
+		width: 48px;
+		height: 48px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
 	}
 </style>


### PR DESCRIPTION
💡 **What**: Replaced the search icon in the domain search input with a loading spinner when a search is in progress.
🎯 **Why**: To provide immediate visual feedback that the input is being processed (debounced search), improving perceived performance and clarity.
📸 **Before/After**: The search icon now transforms into a spinner during loading, maintaining layout stability.
♿ **Accessibility**: Added `role="status"` and `aria-label="Searching"` to the loading indicator to announce state changes to assistive technologies.

---
*PR created automatically by Jules for task [4490786904919242132](https://jules.google.com/task/4490786904919242132) started by @yeboster*