### PR TITLE
⚡ Bolt: Add client-side caching to domain search

### DIFF
--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -8,6 +8,7 @@
 	import { metaNamesSdk } from '$lib/stores/sdk';
 	import { goto } from '$app/navigation';
 	import Icon from 'src/components/Icon.svelte';
+	import { onDestroy } from 'svelte';
 
 	const validator = $metaNamesSdk.domainRepository.domainValidator;
 
@@ -17,6 +18,11 @@
 	let isLoading: boolean = false;
 	let debounceTimer: ReturnType<typeof setTimeout>;
 	let requestId = 0;
+	const cache = new Map<string, DomainModel | null>();
+
+	onDestroy(() => {
+		clearTimeout(debounceTimer);
+	});
 
 	$: errors = invalid ? validator.getErrors() : [];
 	$: invalid = domainName !== '' && !validator.validate(domainName, { raiseError: false });
@@ -42,12 +48,21 @@
 
 		const currentRequestId = ++requestId;
 		nameSearched = domainName.toLocaleLowerCase();
+
+		// Check cache to avoid redundant API calls
+		if (cache.has(nameSearched)) {
+			domain = cache.get(nameSearched);
+			isLoading = false;
+			return;
+		}
+
 		isLoading = true;
 
 		const result = await $metaNamesSdk.domainRepository.find(domainName);
 
 		if (currentRequestId === requestId) {
 			domain = result;
+			cache.set(nameSearched, result);
 			isLoading = false;
 		}
 	}


### PR DESCRIPTION
⚡ Bolt: Add client-side caching to domain search

💡 What: implemented a client-side cache using a Map for domain search results.
🎯 Why: To prevent redundant network requests when users correct typos or revert to previous search terms, improving responsiveness and reducing backend load.
📊 Impact: Eliminates network requests for repeated search terms within the same session (1 request vs N requests).
🔬 Measurement: Verified with a Playwright test counting network requests to `partisiablockchain.com`.


---
*PR created automatically by Jules for task [12513930263836386689](https://jules.google.com/task/12513930263836386689) started by @yeboster*