### PR TITLE
feat(ux): add loading spinner to domain search input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,8 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+
+## 2024-10-25 - Preventing Layout Shifts with Async Loading Indicators
+
+**Learning:** When replacing an icon (like a search button) with a loading spinner during an async operation, explicit sizing is crucial. If the spinner is smaller than the button (e.g., 24px vs 48px), the layout will shift, causing a janky experience.
+**Action:** Always wrap the loading indicator in a container that matches the exact dimensions (width/height/padding) of the element it replaces.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/src/components/DomainPayment.svelte
+++ b/src/components/DomainPayment.svelte
@@ -51,7 +51,7 @@
 		years += amount;
 	}
 
-	async function handleApproveError(error: Error) {
+	async function handleApproveError(error: unknown) {
 		let message;
 		if (error instanceof InsufficientBalanceError)
 			message = {

--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -70,9 +70,15 @@
 		>
 			<svelte:fragment slot="trailingIcon">
 				<div class="submit">
-					<IconButton aria-label="search">
-						<Icon icon="search" />
-					</IconButton>
+					{#if isLoading}
+						<div class="loading-container" role="status" aria-label="Searching">
+							<CircularProgress style="height: 24px; width: 24px;" indeterminate />
+						</div>
+					{:else}
+						<IconButton aria-label="search" on:click={submit}>
+							<Icon icon="search" />
+						</IconButton>
+					{/if}
 				</div>
 			</svelte:fragment>
 			<svelte:fragment slot="helper">
@@ -178,5 +184,13 @@
 
 	.submit {
 		align-self: center;
+	}
+
+	.loading-container {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 48px;
+		height: 48px;
 	}
 </style>


### PR DESCRIPTION
Adds a loading spinner to the domain search input field to provide immediate visual feedback during asynchronous availability checks.

- Replaces the search icon with a `CircularProgress` component when a search is in progress.
- Wraps the spinner in a 48x48px container to prevent layout shifts.
- Adds `role="status"` and `aria-label` for accessibility.
- Ensures the search icon button triggers the search on click.
- Fixes a type error in `DomainPayment.svelte` to pass CI checks.

---
*PR created automatically by Jules for task [4150884214093451661](https://jules.google.com/task/4150884214093451661) started by @yeboster*