### PR TITLE
⚡ Bolt: Add local caching to domain search to reduce API calls

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -17,6 +17,8 @@
 	let isLoading: boolean = false;
 	let debounceTimer: ReturnType<typeof setTimeout>;
 	let requestId = 0;
+	// Cache for domain search results
+	const searchCache = new Map<string, DomainModel | null>();
 
 	$: errors = invalid ? validator.getErrors() : [];
 	$: invalid = domainName !== '' && !validator.validate(domainName, { raiseError: false });
@@ -42,6 +44,12 @@
 
 		const currentRequestId = ++requestId;
 		nameSearched = domainName.toLocaleLowerCase();
+		if (searchCache.has(nameSearched)) {
+			domain = searchCache.get(nameSearched);
+			isLoading = false;
+			return;
+		}
+
 		isLoading = true;
 
 		const result = await $metaNamesSdk.domainRepository.find(domainName);
@@ -49,6 +57,7 @@
 		if (currentRequestId === requestId) {
 			domain = result;
 			isLoading = false;
+			searchCache.set(nameSearched, result);
 		}
 	}
 


### PR DESCRIPTION
💡 What: Implemented a local `Map` cache in `DomainSearch.svelte` to store domain availability results.
🎯 Why: To reduce redundant network requests when users modify and revert search terms (e.g., typing "test", deleting "t", retyping "t").
📊 Impact: Eliminates API calls for repeated search terms within the same session, improving responsiveness and reducing server load.
🔬 Measurement: Verified with a Playwright script that confirms search results appear and cached lookups work.

---
*PR created automatically by Jules for task [10051801736598237505](https://jules.google.com/task/10051801736598237505) started by @yeboster*