### PR TITLE
🎨 Palette: Add loading spinner to domain search input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -70,9 +70,15 @@
 		>
 			<svelte:fragment slot="trailingIcon">
 				<div class="submit">
-					<IconButton aria-label="search">
-						<Icon icon="search" />
-					</IconButton>
+					{#if isLoading}
+						<div class="loading-icon" role="status" aria-label="Searching">
+							<CircularProgress style="height: 24px; width: 24px;" indeterminate />
+						</div>
+					{:else}
+						<IconButton aria-label="search" on:click={submit}>
+							<Icon icon="search" />
+						</IconButton>
+					{/if}
 				</div>
 			</svelte:fragment>
 			<svelte:fragment slot="helper">
@@ -178,5 +184,13 @@
 
 	.submit {
 		align-self: center;
+	}
+
+	.loading-icon {
+		width: 48px;
+		height: 48px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
 	}
 </style>


### PR DESCRIPTION
💡 What: Replaced the static search icon with a spinning loader in the domain search input when a search is active.
🎯 Why: To provide immediate, inline feedback that the application is processing the user's input, improving the perceived responsiveness.
♿ Accessibility: Added 'role="status"' and 'aria-label="Searching"' to the loading indicator.

---
*PR created automatically by Jules for task [160448288323656938](https://jules.google.com/task/160448288323656938) started by @yeboster*