### PR TITLE
⚡ Bolt: Domain Search Caching

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -17,6 +17,10 @@
 	let isLoading: boolean = false;
 	let debounceTimer: ReturnType<typeof setTimeout>;
 	let requestId = 0;
+	// Local cache to store domain availability results.
+	// Key: normalized (lowercase) domain name.
+	// Value: DomainModel (if registered) or null (if available).
+	const cache = new Map<string, DomainModel | null>();
 
 	$: errors = invalid ? validator.getErrors() : [];
 	$: invalid = domainName !== '' && !validator.validate(domainName, { raiseError: false });
@@ -34,20 +38,32 @@
 		if (invalid) return;
 
 		if (domainName === '') return;
-		if (submit && domainName === nameSearched) {
+		const normalizedDomainName = domainName.toLocaleLowerCase();
+
+		if (submit && normalizedDomainName === nameSearched) {
 			const url = domain ? `/domain/${nameSearched}` : `/register/${nameSearched}`;
 
 			return goto(url);
 		}
 
+		if (cache.has(normalizedDomainName)) {
+			// Cache hit: Increment requestId to invalidate any pending network requests from previous inputs.
+			requestId++;
+			nameSearched = normalizedDomainName;
+			domain = cache.get(normalizedDomainName);
+			isLoading = false;
+			return;
+		}
+
 		const currentRequestId = ++requestId;
-		nameSearched = domainName.toLocaleLowerCase();
+		nameSearched = normalizedDomainName;
 		isLoading = true;
 
 		const result = await $metaNamesSdk.domainRepository.find(domainName);
 
 		if (currentRequestId === requestId) {
 			domain = result;
+			cache.set(normalizedDomainName, result);
 			isLoading = false;
 		}
 	}


### PR DESCRIPTION
⚡ Bolt: Domain Search Caching

💡 What:
Implemented a client-side cache for the `DomainSearch` component using a `Map`. It stores the results of domain availability checks keyed by the normalized (lowercase) domain name.

🎯 Why:
To reduce unnecessary API calls to the Partisia Blockchain when a user searches for the same domain multiple times (e.g., while typing, correcting typos, or toggling between similar names).

📊 Impact:
- Reduces API calls for repeated searches to 0.
- Immediate feedback for cached results (no loading spinner).
- Improves perceived performance and reduces backend load.

🔬 Measurement:
1. Open the app and go to the home page.
2. Open Network tab in DevTools.
3. Type "alice". Observe the API call.
4. Clear the input and type "alice" again.
5. Observe that no new API call is made, and the result appears instantly.


---
*PR created automatically by Jules for task [6588411976478618680](https://jules.google.com/task/6588411976478618680) started by @yeboster*