### PR TITLE
🎨 Palette: Add loading spinner to domain search input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,8 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+
+## 2024-10-24 - Input Field Loading Indicators
+
+**Learning:** When implementing debounced search inputs, relying solely on a separate results area loader disconnects the feedback from the user's action (typing). Users expect immediate validation that their input is being processed.
+**Action:** Always include a small, inline loading indicator (spinner) within the input field itself (e.g., trailing icon slot) for async search operations, ensuring it has `role="status"` and `aria-label`.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -70,9 +70,15 @@
 		>
 			<svelte:fragment slot="trailingIcon">
 				<div class="submit">
-					<IconButton aria-label="search">
-						<Icon icon="search" />
-					</IconButton>
+					{#if isLoading}
+						<div class="loading-icon" role="status" aria-label="Searching...">
+							<CircularProgress style="height: 24px; width: 24px;" indeterminate />
+						</div>
+					{:else}
+						<IconButton aria-label="search">
+							<Icon icon="search" />
+						</IconButton>
+					{/if}
 				</div>
 			</svelte:fragment>
 			<svelte:fragment slot="helper">
@@ -178,5 +184,13 @@
 
 	.submit {
 		align-self: center;
+	}
+
+	.loading-icon {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 48px;
+		height: 48px;
 	}
 </style>


### PR DESCRIPTION
💡 What: Replaced the static search icon in the domain search input with a loading spinner when a search is in progress.
🎯 Why: To provide immediate visual feedback to the user while they are typing and the system is debouncing/searching, improving perceived performance and responsiveness.
📸 Before/After: The input now shows a CircularProgress spinner instead of the search icon during loading.
♿ Accessibility: Added `role="status"` and `aria-label="Searching..."` to the spinner container for screen readers.

---
*PR created automatically by Jules for task [18116272601630775040](https://jules.google.com/task/18116272601630775040) started by @yeboster*