### PR TITLE
⚡ Bolt: Add persistent caching to domain search

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,0 +1,31 @@
+## 2024-10-24 - Svelte Store Lifecycle & Caching
+
+**Learning:** In Svelte, simple local variables in components (like a `Map` or a debounce timer) persist only as long as the component is mounted. However, `Map` objects initialized outside the component instance (module-level) would be shared across all instances, which is often what we want for a cache but requires careful management. In this specific case, I initialized the `searchCache` _inside_ the component script block. Wait, let me double check my code.
+
+I put `const searchCache = new Map<string, DomainModel | null>();` _inside_ the `<script lang="ts">` block. In Svelte, the code inside `<script>` runs when the component is instantiated. Therefore, `searchCache` is created _per component instance_. This means if the user navigates away and comes back, the cache is lost.
+
+**Correction:** To make the cache persistent across navigations (which is the main point of caching search results in a SPA), the cache should be declared _outside_ the component or in a separate store/module.
+
+However, `src/routes/DomainSearch.svelte` is a route component or used in one. If I want the cache to persist while the user is browsing the app, I should move the cache declaration to a module-level context or a separate file.
+
+Let's check `src/routes/DomainSearch.svelte` again.
+It has `<script lang="ts">`.
+If I want it to persist, I should put it in `<script context="module">` or just import it from a shared store.
+Or, simply move the declaration `const searchCache ...` to be outside the component logic? No, in `.svelte` files, code in `<script>` is per-instance.
+
+**Action:** I need to move `searchCache` to a module context or a separate file to ensure it persists across page navigations. Otherwise, the cache is only useful if the user types, clears, and types again without leaving the component. Given the user experience "Find your Meta Name", users might search, go to a page, come back.
+Actually, the current implementation is `const searchCache = ...` inside the script. This is per-instance.
+If I want it global, I should use:
+
+```svelte
+<script context="module" lang="ts">
+	import type { Domain as DomainModel } from '@metanames/sdk';
+	const searchCache = new Map<string, DomainModel | null>();
+</script>
+
+<script lang="ts">
+	// ... rest of the code
+</script>
+```
+
+Let me fix this optimization to be actually effective.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -1,13 +1,19 @@
+<script context="module" lang="ts">
+	import type { Domain as DomainModel } from '@metanames/sdk';
+
+	const searchCache = new Map<string, DomainModel | null>();
+</script>
+
 <script lang="ts">
 	import Card, { Content as CardContent } from '@smui/card';
 	import CircularProgress from '@smui/circular-progress';
 	import Textfield from '@smui/textfield';
 	import HelperText from '@smui/textfield/helper-text';
-	import type { Domain as DomainModel } from '@metanames/sdk';
 	import IconButton from '@smui/icon-button';
 	import { metaNamesSdk } from '$lib/stores/sdk';
 	import { goto } from '$app/navigation';
 	import Icon from 'src/components/Icon.svelte';
+	import { onDestroy } from 'svelte';
 
 	const validator = $metaNamesSdk.domainRepository.domainValidator;
 
@@ -17,6 +23,10 @@
 	let isLoading: boolean = false;
 	let debounceTimer: ReturnType<typeof setTimeout>;
 	let requestId = 0;
+
+	onDestroy(() => {
+		clearTimeout(debounceTimer);
+	});
 
 	$: errors = invalid ? validator.getErrors() : [];
 	$: invalid = domainName !== '' && !validator.validate(domainName, { raiseError: false });
@@ -44,10 +54,17 @@
 		nameSearched = domainName.toLocaleLowerCase();
 		isLoading = true;
 
+		if (searchCache.has(nameSearched)) {
+			domain = searchCache.get(nameSearched);
+			isLoading = false;
+			return;
+		}
+
 		const result = await $metaNamesSdk.domainRepository.find(domainName);
 
 		if (currentRequestId === requestId) {
 			domain = result;
+			searchCache.set(nameSearched, result);
 			isLoading = false;
 		}
 	}

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "failed",
+  "failedTests": []
+}


### PR DESCRIPTION
⚡ **Bolt Performance Update**

### 💡 What
Implemented a persistent local cache for domain search results in `src/routes/DomainSearch.svelte`.

### 🎯 Why
Repeated searches for the same domain name were triggering redundant network requests to the Partisia Blockchain SDK. This added unnecessary latency and network load.

### 📊 Impact
- Eliminates network requests for previously searched domains within the same session.
- Immediate feedback for cached results (no loading spinner).
- Reduces API load on the backend.

###  microscopes Measurement
1. Open the app and search for "test".
2. Observe the network request (and loading spinner).
3. Clear the search and search for "test" again.
4. Verify that no new network request is made and the result appears instantly.


---
*PR created automatically by Jules for task [17395741679872538609](https://jules.google.com/task/17395741679872538609) started by @yeboster*