### PR TITLE
🎨 Palette: Fix dialog accessibility duplicate IDs in Record component

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,8 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+
+## 2024-10-24 - Deterministic Unique IDs for Dialog Accessibility in Loops
+
+**Learning:** Hardcoded IDs for inner components (like `Title` and `Content`) in a `<Dialog>` break `aria-labelledby` and `aria-describedby` mappings when the dialog is rendered multiple times (e.g., inside an `{#each}` loop). This breaks accessibility for screen readers and produces invalid HTML due to duplicate IDs.
+**Action:** Use deterministic props (like `klass` or `id`) to generate unique values for `id`, `aria-labelledby`, and `aria-describedby` attributes in dialogs rendered within a loop.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/src/components/Record.svelte
+++ b/src/components/Record.svelte
@@ -55,11 +55,11 @@
 <div class="record-container {editMode ? 'edit' : ''}">
 	<Dialog
 		bind:open={dialogOpen}
-		aria-labelledby="confirmation-title"
-		aria-describedby="confirmation-content"
+		aria-labelledby="confirmation-title-{klass}"
+		aria-describedby="confirmation-content-{klass}"
 	>
-		<Title id="simple-title">Confirm action</Title>
-		<Content id="simple-content">Do you really want to remove the record?</Content>
+		<Title id="confirmation-title-{klass}">Confirm action</Title>
+		<Content id="confirmation-content-{klass}">Do you really want to remove the record?</Content>
 		<Actions>
 			<Button>
 				<Label>No</Label>


### PR DESCRIPTION
💡 **What:**
Updated `src/components/Record.svelte` to use deterministic IDs for the inner `<Title>` and `<Content>` components of the SMUI `<Dialog>`. Updated the dialog's `aria-labelledby` and `aria-describedby` tags to correctly point to these new unique IDs. Also added a journal entry to `.Jules/palette.md` noting the importance of this accessibility change.

🎯 **Why:**
When `<Record>` components are rendered in a loop, hardcoding `id="simple-title"` and `id="simple-content"` inside the dialog creates duplicate IDs on the page, violating HTML validity. Furthermore, because multiple dialogs exist with those same IDs, screen readers get confused and the `aria-labelledby` associations break. Making the IDs deterministic (using the unique `klass` string) ensures robust accessibility compliance.

♿ **Accessibility:**
Screen readers will now correctly read the dialog title and content for each specific record edit/delete action. Resolved a duplicate ID violation when multiple dialogs are present in the DOM.

---
*PR created automatically by Jules for task [9522691433753552843](https://jules.google.com/task/9522691433753552843) started by @yeboster*