### PR TITLE
⚡ Bolt: Add module-scoped caching for domain searches

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,8 @@
 
 **Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
 **Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.
+
+## 2024-10-26 - Svelte Module Scope Caching
+
+**Learning:** Svelte's `<script context="module">` is a perfect, lightweight alternative to global stores for persistent component-level caching. Variables declared here persist across component mount/unmount cycles and navigations, making it ideal for caching local search results (like domain lookups) without cluttering the global state.
+**Action:** Use module-scoped variables for component-specific caching (like a `Map` of search results) to improve performance on repeated searches.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -1,4 +1,14 @@
+<script context="module" lang="ts">
+	import type { Domain as DomainModelModule } from '@metanames/sdk';
+
+	// Cache to store domain search results, persisting across component instances and navigations
+	// Includes a timestamp to invalidate stale data after a short TTL (e.g., 1 minute)
+	const domainCache = new Map<string, { data: DomainModelModule | null; timestamp: number }>();
+	const CACHE_TTL_MS = 60 * 1000; // 1 minute
+</script>
+
 <script lang="ts">
+	import { onDestroy } from 'svelte';
 	import Card, { Content as CardContent } from '@smui/card';
 	import CircularProgress from '@smui/circular-progress';
 	import Textfield from '@smui/textfield';
@@ -17,6 +27,11 @@
 	let isLoading: boolean = false;
 	let debounceTimer: ReturnType<typeof setTimeout>;
 	let requestId = 0;
+
+	// Clear timer on component destroy to prevent memory leaks
+	onDestroy(() => {
+		clearTimeout(debounceTimer);
+	});
 
 	$: errors = invalid ? validator.getErrors() : [];
 	$: invalid = domainName !== '' && !validator.validate(domainName, { raiseError: false });
@@ -40,14 +55,27 @@
 			return goto(url);
 		}
 
-		const currentRequestId = ++requestId;
 		nameSearched = domainName.toLocaleLowerCase();
+
+		const cachedResult = domainCache.get(nameSearched);
+		const isCacheValid = cachedResult && Date.now() - cachedResult.timestamp < CACHE_TTL_MS;
+
+		if (isCacheValid) {
+			// Increment request ID to invalidate any pending network requests
+			++requestId;
+			domain = cachedResult.data;
+			isLoading = false;
+			return;
+		}
+
+		const currentRequestId = ++requestId;
 		isLoading = true;
 
 		const result = await $metaNamesSdk.domainRepository.find(domainName);
 
 		if (currentRequestId === requestId) {
 			domain = result;
+			domainCache.set(nameSearched, { data: result ?? null, timestamp: Date.now() });
 			isLoading = false;
 		}
 	}


### PR DESCRIPTION
💡 **What**:
Implemented a client-side cache for domain searches using Svelte's `<script context="module">`. The cache stores results based on the lowercased search term and includes a 1-minute TTL to invalidate stale data. It also correctly updates the `requestId` to prevent stale pending API requests from overwriting cached results. Added an `onDestroy` hook to clear the input debounce timer. Added a journal entry about this pattern in `.jules/bolt.md`.

🎯 **Why**: 
When a user frequently checks domains or toggles back and forth between results, the app was needlessly re-fetching data from the blockchain network via the SDK, causing UI loading states and unnecessary network traffic. Also, if a user typed quickly and navigated away, the debounce timer could potentially leak.

📊 **Impact**:
- **Reduces network latency** to ~0ms for repeated searches within the 1-minute TTL window.
- Eliminates the visual loading spinner when returning to a previously checked domain.
- Prevents memory leaks by properly clearing the debounce timer on unmount.

🔬 **Measurement**:
Start the dev server and search for a domain (e.g., "test"). Notice the loading spinner. Clear the input and search for the same domain again within 1 minute. The result should appear instantly without a network request or loading state.

---
*PR created automatically by Jules for task [15492721158557477078](https://jules.google.com/task/15492721158557477078) started by @yeboster*