### PR TITLE
⚡ Bolt: [performance improvement] Execute SDK queries concurrently in getStats

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -44,11 +44,12 @@ export interface DomainStats {
 }
 
 export const getStats = async (): Promise<DomainStats> => {
-	const domainCount = await metaNamesSdk.domainRepository.count();
-	const ownerCount = await metaNamesSdk.domainRepository
-		.getOwners()
-		.then((owners) => owners.length);
-	const recentDomains = await getRecentDomains();
+	// Execute SDK queries concurrently to avoid waterfall latency and improve API endpoint performance
+	const [domainCount, ownerCount, recentDomains] = await Promise.all([
+		metaNamesSdk.domainRepository.count(),
+		metaNamesSdk.domainRepository.getOwners().then((owners) => owners.length),
+		getRecentDomains()
+	]);
 
 	return {
 		domainCount,


### PR DESCRIPTION
⚡ Bolt: [performance improvement] Execute SDK queries concurrently in getStats

💡 What: Modified the `getStats` function in `src/lib/server/index.ts` to execute its 3 independent asynchronous requests concurrently using `Promise.all()`.
🎯 Why: The previous implementation performed these requests sequentially: `domainRepository.count()`, then `domainRepository.getOwners()`, and finally `getRecentDomains()`. This resulted in waterfall latency where each request had to wait for the previous one to complete.
📊 Impact: Expected reduction in total response time for the statistics API endpoint, directly equal to the time saved by running the two slower requests concurrently with the slowest one, rather than summing their execution times.
🔬 Measurement: Verified that unit tests pass, type-check passes, linting is green, and the changes are cleanly implemented with appropriate comments. The output of the function remains completely unchanged.

---
*PR created automatically by Jules for task [3923450529445998877](https://jules.google.com/task/3923450529445998877) started by @yeboster*