### PR TITLE
🎨 Palette: fix ARIA labels and alt text for accessibility

### DIFF
--- a/src/components/Record.svelte
+++ b/src/components/Record.svelte
@@ -55,11 +55,11 @@
 <div class="record-container {editMode ? 'edit' : ''}">
 	<Dialog
 		bind:open={dialogOpen}
-		aria-labelledby="confirmation-title"
-		aria-describedby="confirmation-content"
+		aria-labelledby="confirmation-title-{klass}"
+		aria-describedby="confirmation-content-{klass}"
 	>
-		<Title id="simple-title">Confirm action</Title>
-		<Content id="simple-content">Do you really want to remove the record?</Content>
+		<Title id="confirmation-title-{klass}">Confirm action</Title>
+		<Content id="confirmation-content-{klass}">Do you really want to remove the record?</Content>
 		<Actions>
 			<Button>
 				<Label>No</Label>

--- a/src/routes/WalletConnectButton.svelte
+++ b/src/routes/WalletConnectButton.svelte
@@ -134,7 +134,7 @@
 			<Item on:SMUI:action={connectWithLedgerWallet}>
 				<Text>
 					<div class="item">
-						<img class="logo" src={ledgerWalletLogo} alt="partisia wallet logo" />
+						<img class="logo" src={ledgerWalletLogo} alt="ledger wallet logo" />
 						<span>Ledger</span>
 					</div>
 				</Text>


### PR DESCRIPTION
💡 **What**: 
1. The `Dialog` component inside `src/components/Record.svelte` had static IDs for `Title` and `Content`, leading to duplicate IDs and incorrect ARIA associations when multiple records were displayed. This has been fixed by appending a dynamic `{klass}` variable to the IDs and ARIA references.
2. The image tag for the Ledger wallet icon in `src/routes/WalletConnectButton.svelte` contained incorrect `alt` text ("partisia wallet logo"). It was updated to "ledger wallet logo".

🎯 **Why**: 
To improve accessibility and ensure screen readers can accurately interpret both the confirmation dialogs and the wallet connection options.

♿ **Accessibility**: 
- Ensure unique IDs for modal components and proper ARIA relationships (`aria-labelledby` and `aria-describedby`).
- Ensure images provide accurate `alt` text for screen readers.

---
*PR created automatically by Jules for task [145024227146722502](https://jules.google.com/task/145024227146722502) started by @yeboster*