### PR TITLE
⚡ Bolt: optimize domain stats retrieval with Promise.all

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,8 @@
 
 **Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
 **Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.
+
+## 2024-10-25 - API Route Tradeoffs with Promise.all
+
+**Learning:** When trying to eliminate waterfall requests using `Promise.all` in an API route, consider error/failure paths. Executing requests concurrently means you might perform an expensive query *before* a validation check fails. In some cases, like verifying a voting deadline before fetching a heavy list of owners, the sequential waterfall is actually better for performance on the failure path than a concurrent execution that over-fetches.
+**Action:** Always evaluate the tradeoffs between "happy path" speed (concurrency) and "failure path" efficiency (sequential short-circuiting). Do not use `Promise.all` blindly across validation boundaries.

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -44,11 +44,12 @@ export interface DomainStats {
 }
 
 export const getStats = async (): Promise<DomainStats> => {
-	const domainCount = await metaNamesSdk.domainRepository.count();
-	const ownerCount = await metaNamesSdk.domainRepository
-		.getOwners()
-		.then((owners) => owners.length);
-	const recentDomains = await getRecentDomains();
+	// Execute independent asynchronous SDK requests concurrently to avoid waterfall latency
+	const [domainCount, ownerCount, recentDomains] = await Promise.all([
+		metaNamesSdk.domainRepository.count(),
+		metaNamesSdk.domainRepository.getOwners().then((owners) => owners.length),
+		getRecentDomains()
+	]);
 
 	return {
 		domainCount,


### PR DESCRIPTION
💡 **What**: The sequential asynchronous operations in `getStats` inside `src/lib/server/index.ts` have been updated to execute concurrently using `Promise.all`.
🎯 **Why**: The original implementation awaited each SDK query (domain count, owner count, and recent domains) sequentially. Since these queries are independent and do not rely on each other, fetching them sequentially creates an unnecessary waterfall effect, slowing down the API response.
📊 **Impact**: Reduces latency when retrieving domain statistics. The total execution time of `getStats` changes from the sum of the three network calls to roughly the duration of the slowest single call. 
🔬 **Measurement**: Verify by calling the stats endpoint (`/api/domains/stats`) and profiling the network timings; it should resolve faster than before without sequentially chained server requests. Also noted the tradeoffs for failure paths when considering `Promise.all` in the Bolt journal!

---
*PR created automatically by Jules for task [9592291343000552514](https://jules.google.com/task/9592291343000552514) started by @yeboster*