### PR TITLE
⚡ Bolt: Optimize getStats to run queries concurrently

### DIFF
--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -44,11 +44,13 @@ export interface DomainStats {
 }
 
 export const getStats = async (): Promise<DomainStats> => {
-	const domainCount = await metaNamesSdk.domainRepository.count();
-	const ownerCount = await metaNamesSdk.domainRepository
-		.getOwners()
-		.then((owners) => owners.length);
-	const recentDomains = await getRecentDomains();
+	// ⚡ Bolt: Fetch domain stats concurrently using Promise.all to avoid waterfall latency.
+	// This reduces the total execution time from O(a + b + c) to O(max(a, b, c)).
+	const [domainCount, ownerCount, recentDomains] = await Promise.all([
+		metaNamesSdk.domainRepository.count(),
+		metaNamesSdk.domainRepository.getOwners().then((owners) => owners.length),
+		getRecentDomains()
+	]);
 
 	return {
 		domainCount,


### PR DESCRIPTION
💡 **What:** The `getStats` function in `src/lib/server/index.ts` was refactored to fetch `domainCount`, `ownerCount`, and `recentDomains` concurrently using `Promise.all`.

🎯 **Why:** The previous implementation was awaiting each of the three operations sequentially, creating a waterfall latency where the total time was the sum of all three queries. Since these three operations are independent, there was an opportunity to run them in parallel to optimize the function's execution time.

📊 **Impact:** Reduces the total execution time from O(a + b + c) to O(max(a, b, c)), significantly speeding up the endpoint (`/api/domains/stats`).

🔬 **Measurement:** You can verify this by checking the performance of the `/api/domains/stats` endpoint. Also all existing unit tests and type checks pass.

---
*PR created automatically by Jules for task [10291016605350931454](https://jules.google.com/task/10291016605350931454) started by @yeboster*