### PR TITLE
⚡ Bolt: Avoid waterfall latency in getStats with Promise.all

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -44,11 +44,13 @@ export interface DomainStats {
 }
 
 export const getStats = async (): Promise<DomainStats> => {
-	const domainCount = await metaNamesSdk.domainRepository.count();
-	const ownerCount = await metaNamesSdk.domainRepository
-		.getOwners()
-		.then((owners) => owners.length);
-	const recentDomains = await getRecentDomains();
+	// ⚡ Bolt: Fetch stats concurrently to avoid waterfall latency
+	// Reduces total execution time from sum of requests to max of requests
+	const [domainCount, ownerCount, recentDomains] = await Promise.all([
+		metaNamesSdk.domainRepository.count(),
+		metaNamesSdk.domainRepository.getOwners().then((owners) => owners.length),
+		getRecentDomains()
+	]);
 
 	return {
 		domainCount,


### PR DESCRIPTION
💡 **What:** 
Refactored the `getStats` function in `src/lib/server/index.ts` to use `Promise.all`. This fetches `domainCount`, `ownerCount`, and `recentDomains` concurrently rather than sequentially.

🎯 **Why:** 
The previous implementation fetched data in a sequential "waterfall", where each request waited for the previous one to complete despite them being completely independent. 

📊 **Impact:** 
Reduces the execution time of `getStats` (and thus API response time for the dashboard stats) from the sum of all three SDK/network requests down to the maximum duration of the single slowest request. Expect significantly faster response times.

🔬 **Measurement:** 
Run `yarn test:unit --run` to ensure no errors. Check network times on the stats endpoint (or `/api/domains/stats`); the time-to-first-byte should be observably lower compared to `main`.

---
*PR created automatically by Jules for task [10912777582638707955](https://jules.google.com/task/10912777582638707955) started by @yeboster*