### PR TITLE
🎨 Palette: Fix duplicate IDs and ARIA mappings in Record dialogs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/src/components/Record.svelte
+++ b/src/components/Record.svelte
@@ -55,11 +55,11 @@
 <div class="record-container {editMode ? 'edit' : ''}">
 	<Dialog
 		bind:open={dialogOpen}
-		aria-labelledby="confirmation-title"
-		aria-describedby="confirmation-content"
+		aria-labelledby="confirmation-title-{label}"
+		aria-describedby="confirmation-content-{label}"
 	>
-		<Title id="simple-title">Confirm action</Title>
-		<Content id="simple-content">Do you really want to remove the record?</Content>
+		<Title id="confirmation-title-{label}">Confirm action</Title>
+		<Content id="confirmation-content-{label}">Do you really want to remove the record?</Content>
 		<Actions>
 			<Button>
 				<Label>No</Label>


### PR DESCRIPTION
💡 **What:** 
Updated the `<Dialog>` implementation within `src/components/Record.svelte` to use dynamic, instance-specific IDs (using the record's `label`) for its title and content elements.

🎯 **Why:** 
Previously, the dialog used hardcoded IDs (`id="simple-title"`, `id="simple-content"`) but was referenced via mismatched ARIA attributes (`aria-labelledby="confirmation-title"`, `aria-describedby="confirmation-content"`). Furthermore, because multiple `Record` components can be rendered on the same page (e.g., in a list of domains), the hardcoded IDs resulted in invalid, duplicate HTML IDs across the DOM. This broke screen reader functionality because the IDs were not unique and the ARIA attributes pointed to non-existent IDs.

♿ **Accessibility:** 
- Resolved missing target errors for `aria-labelledby` and `aria-describedby`.
- Fixed duplicate HTML ID violations, ensuring that screen readers properly announce the dialog content for each individual record instance.

---
*PR created automatically by Jules for task [14400756564660741485](https://jules.google.com/task/14400756564660741485) started by @yeboster*