### PR TITLE
🎨 Palette: Contextual Profile Search Icon

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,9 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.
+
+## 2024-05-19 - Contextual Icon Swap for Search Inputs
+
+**Learning:** Having an enabled "clear/cancel" icon in an empty search field can confuse users or give false affordance. A disabled search icon initially, which swaps to a functional "clear search" icon once text is present, establishes clearer intent and immediate feedback.
+**Action:** When implementing search inputs, provide contextual icons: a disabled magnifying glass for an empty state, and an enabled "clear" button for a filled state. Ensure `aria-label`s reflect the active icon's purpose accurately (e.g., `aria-label="clear search"`).

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -37,9 +37,7 @@
 		const trimmedDomain = domain.trim().toLowerCase();
 		const trimmedSearch = search.trim().toLowerCase();
 
-		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
-			return true;
-		else false;
+		return trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch);
 	}
 </script>
 
@@ -59,9 +57,15 @@
 				>
 					<svelte:fragment slot="trailingIcon">
 						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
+							{#if search !== ''}
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							{:else}
+								<IconButton aria-label="search domains" disabled>
+									<Icon icon="search" />
+								</IconButton>
+							{/if}
 						</div>
 					</svelte:fragment>
 				</Textfield>


### PR DESCRIPTION
💡 What: Changed the persistent "cancel" icon in the profile search bar to a contextual icon. It now shows a disabled "search" magnifying glass when the input is empty, and swaps to a functional "cancel" icon when text is entered. Also updated the `isFuzzyMatch` return logic to eliminate redundant boolean evaluations.
🎯 Why: A "cancel/clear" icon gives a false affordance when there is nothing to clear. Showing a search icon provides better context, while replacing it dynamically prevents visual clutter.
📸 Before/After: Before, empty search bars had an active X icon. Now, they have a disabled magnifying glass.
♿ Accessibility: Updated the `aria-label` from a generic "cancel" to "clear search" (when active) and "search domains" (when disabled), improving screen reader clarity.

---
*PR created automatically by Jules for task [172110034238249600](https://jules.google.com/task/172110034238249600) started by @yeboster*