### PR TITLE
🎨 Palette: Contextual search input icons in profile page

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/.svelte-kit/tsconfig.json
+++ b/.svelte-kit/tsconfig.json
@@ -9,6 +9,9 @@
 			],
 			"$lib/*": [
 				"../src/lib/*"
+			],
+			"$app/types": [
+				"./types/index.d.ts"
 			]
 		},
 		"rootDirs": [
@@ -36,6 +39,9 @@
 		"../src/**/*.js",
 		"../src/**/*.ts",
 		"../src/**/*.svelte",
+		"../test/**/*.js",
+		"../test/**/*.ts",
+		"../test/**/*.svelte",
 		"../tests/**/*.js",
 		"../tests/**/*.ts",
 		"../tests/**/*.svelte"

--- a/dev_output.log
+++ b/dev_output.log
@@ -1,0 +1,265 @@
+
+> meta-names-app@1.0.0 dev /app
+> vite dev
+
+
+  VITE v5.4.21  ready in 2274 ms
+
+  ➜  Local:   http://localhost:5173/
+  ➜  Network: use --host to expose
+8:59:10 PM [vite-plugin-svelte] /app/src/components/Icon.svelte:31:1 No scopable elements found in template. If you're using global styles in the style tag, you should move it into an external stylesheet file and import it in JS. See https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#where-should-i-put-my-global-styles.
+DEPRECATION WARNING [legacy-js-api]: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.
+
+More info: https://sass-lang.com/d/legacy-js-api
+
+DEPRECATION WARNING [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+  ╷
+1 │ @import './theme-overrides.scss';
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^
+  ╵
+    src/styles/app.scss 1:9  root stylesheet
+
+DEPRECATION WARNING [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+  ╷
+2 │ @import './mixins.scss';
+  │         ^^^^^^^^^^^^^^^
+  ╵
+    src/styles/app.scss 2:9  root stylesheet
+
+Unable to resolve `@import "./theme/smui-dark.css"` from /app/src/styles
+8:59:10 PM [vite] Pre-transform error: [postcss] ENOENT: no such file or directory, open './theme/smui-dark.css'
+DEPRECATION WARNING [legacy-js-api]: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.
+
+More info: https://sass-lang.com/d/legacy-js-api
+
+8:59:11 PM [vite-plugin-svelte] /app/node_modules/.pnpm/@smui+snackbar@7.0.0_svelte@4.2.20_typescript@5.9.3/node_modules/@smui/snackbar/dist/Snackbar.svelte:16:2 A11y: Non-interactive element <div> should not be assigned mouse or keyboard event listeners.
+8:59:11 PM [vite-plugin-svelte] /app/node_modules/.pnpm/@smui+snackbar@7.0.0_svelte@4.2.20_typescript@5.9.3/node_modules/@smui/snackbar/dist/Snackbar.svelte:1:0 A11y: Non-interactive element <aside> should not be assigned mouse or keyboard event listeners.
+8:59:11 PM [vite-plugin-svelte] /app/node_modules/.pnpm/@smui+menu-surface@7.0.0_svelte@4.2.20_typescript@5.9.3/node_modules/@smui/menu-surface/dist/MenuSurface.svelte:3:0 A11y: Non-interactive element <div> should not be assigned mouse or keyboard event listeners.
+DEPRECATION WARNING [legacy-js-api]: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.
+
+More info: https://sass-lang.com/d/legacy-js-api
+
+DEPRECATION WARNING [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+  ╷
+1 │ @import './theme-overrides.scss';
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^
+  ╵
+    src/styles/app.scss 1:9  root stylesheet
+
+DEPRECATION WARNING [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+  ╷
+2 │ @import './mixins.scss';
+  │         ^^^^^^^^^^^^^^^
+  ╵
+    src/styles/app.scss 2:9  root stylesheet
+
+Unable to resolve `@import "./theme/smui-dark.css"` from /app/src/styles
+8:59:15 PM [vite] Error when evaluating SSR module /src/routes/+layout.svelte:
+|- Error: [postcss] ENOENT: no such file or directory, open './theme/smui-dark.css'
+    at async open (node:internal/fs/promises:636:25)
+    at async Object.readFile (node:internal/fs/promises:1235:14)
+    at async Object.load (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36835:25)
+    at async loadImportContent (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:844:19)
+    at async Promise.all (index 0)
+    at async resolveImportId (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:800:27)
+    at async parseStyles$1 (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:708:5)
+    at async Object.Once (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:965:22)
+    at async LazyResult.runAsync (/app/node_modules/.pnpm/postcss@8.5.8/node_modules/postcss/lib/lazy-result.js:293:11)
+    at async compileCSS (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36898:21)
+
+Error: [postcss] ENOENT: no such file or directory, open './theme/smui-dark.css'
+    at async open (node:internal/fs/promises:636:25)
+    at async Object.readFile (node:internal/fs/promises:1235:14)
+    at async Object.load (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36835:25)
+    at async loadImportContent (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:844:19)
+    at async Promise.all (index 0)
+    at async resolveImportId (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:800:27)
+    at async parseStyles$1 (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:708:5)
+    at async Object.Once (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:965:22)
+    at async LazyResult.runAsync (/app/node_modules/.pnpm/postcss@8.5.8/node_modules/postcss/lib/lazy-result.js:293:11)
+    at async compileCSS (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36898:21)
+Error: [postcss] ENOENT: no such file or directory, open './theme/smui-dark.css'
+    at async open (node:internal/fs/promises:636:25)
+    at async Object.readFile (node:internal/fs/promises:1235:14)
+    at async Object.load (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36835:25)
+    at async loadImportContent (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:844:19)
+    at async Promise.all (index 0)
+    at async resolveImportId (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:800:27)
+    at async parseStyles$1 (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:708:5)
+    at async Object.Once (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:965:22)
+    at async LazyResult.runAsync (/app/node_modules/.pnpm/postcss@8.5.8/node_modules/postcss/lib/lazy-result.js:293:11)
+    at async compileCSS (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36898:21)
+Error: [postcss] ENOENT: no such file or directory, open './theme/smui-dark.css'
+    at async open (node:internal/fs/promises:636:25)
+    at async Object.readFile (node:internal/fs/promises:1235:14)
+    at async Object.load (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36835:25)
+    at async loadImportContent (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:844:19)
+    at async Promise.all (index 0)
+    at async resolveImportId (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:800:27)
+    at async parseStyles$1 (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:708:5)
+    at async Object.Once (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:965:22)
+    at async LazyResult.runAsync (/app/node_modules/.pnpm/postcss@8.5.8/node_modules/postcss/lib/lazy-result.js:293:11)
+    at async compileCSS (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36898:21)
+Error: [postcss] ENOENT: no such file or directory, open './theme/smui-dark.css'
+    at async open (node:internal/fs/promises:636:25)
+    at async Object.readFile (node:internal/fs/promises:1235:14)
+    at async Object.load (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36835:25)
+    at async loadImportContent (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:844:19)
+    at async Promise.all (index 0)
+    at async resolveImportId (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:800:27)
+    at async parseStyles$1 (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:708:5)
+    at async Object.Once (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:965:22)
+    at async LazyResult.runAsync (/app/node_modules/.pnpm/postcss@8.5.8/node_modules/postcss/lib/lazy-result.js:293:11)
+    at async compileCSS (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36898:21)
+9:00:23 PM [vite] ✨ new dependencies optimized: vite-plugin-node-polyfills/shims/buffer, vite-plugin-node-polyfills/shims/global, vite-plugin-node-polyfills/shims/process
+9:00:23 PM [vite] ✨ optimized dependencies changed. reloading
+9:00:23 PM [vite-plugin-svelte] /app/src/components/Icon.svelte:31:1 No scopable elements found in template. If you're using global styles in the style tag, you should move it into an external stylesheet file and import it in JS. See https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#where-should-i-put-my-global-styles.
+DEPRECATION WARNING [legacy-js-api]: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.
+
+More info: https://sass-lang.com/d/legacy-js-api
+
+DEPRECATION WARNING [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+  ╷
+1 │ @import './theme-overrides.scss';
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^
+  ╵
+    src/styles/app.scss 1:9  root stylesheet
+
+DEPRECATION WARNING [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+  ╷
+2 │ @import './mixins.scss';
+  │         ^^^^^^^^^^^^^^^
+  ╵
+    src/styles/app.scss 2:9  root stylesheet
+
+Unable to resolve `@import "./theme/smui-dark.css"` from /app/src/styles
+9:00:23 PM [vite] Pre-transform error: [postcss] ENOENT: no such file or directory, open './theme/smui-dark.css'
+DEPRECATION WARNING [legacy-js-api]: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.
+
+More info: https://sass-lang.com/d/legacy-js-api
+
+9:00:23 PM [vite-plugin-svelte] /app/node_modules/.pnpm/@smui+snackbar@7.0.0_svelte@4.2.20_typescript@5.9.3/node_modules/@smui/snackbar/dist/Snackbar.svelte:16:2 A11y: Non-interactive element <div> should not be assigned mouse or keyboard event listeners.
+9:00:23 PM [vite-plugin-svelte] /app/node_modules/.pnpm/@smui+snackbar@7.0.0_svelte@4.2.20_typescript@5.9.3/node_modules/@smui/snackbar/dist/Snackbar.svelte:1:0 A11y: Non-interactive element <aside> should not be assigned mouse or keyboard event listeners.
+9:00:23 PM [vite-plugin-svelte] /app/node_modules/.pnpm/@smui+menu-surface@7.0.0_svelte@4.2.20_typescript@5.9.3/node_modules/@smui/menu-surface/dist/MenuSurface.svelte:3:0 A11y: Non-interactive element <div> should not be assigned mouse or keyboard event listeners.
+DEPRECATION WARNING [legacy-js-api]: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.
+
+More info: https://sass-lang.com/d/legacy-js-api
+
+DEPRECATION WARNING [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+  ╷
+1 │ @import './theme-overrides.scss';
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^
+  ╵
+    src/styles/app.scss 1:9  root stylesheet
+
+DEPRECATION WARNING [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+  ╷
+2 │ @import './mixins.scss';
+  │         ^^^^^^^^^^^^^^^
+  ╵
+    src/styles/app.scss 2:9  root stylesheet
+
+Unable to resolve `@import "./theme/smui-dark.css"` from /app/src/styles
+9:00:24 PM [vite] Error when evaluating SSR module /src/routes/+layout.svelte:
+|- Error: [postcss] ENOENT: no such file or directory, open './theme/smui-dark.css'
+    at async open (node:internal/fs/promises:636:25)
+    at async Object.readFile (node:internal/fs/promises:1235:14)
+    at async Object.load (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36835:25)
+    at async loadImportContent (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:844:19)
+    at async Promise.all (index 0)
+    at async resolveImportId (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:800:27)
+    at async parseStyles$1 (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:708:5)
+    at async Object.Once (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:965:22)
+    at async LazyResult.runAsync (/app/node_modules/.pnpm/postcss@8.5.8/node_modules/postcss/lib/lazy-result.js:293:11)
+    at async compileCSS (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36898:21)
+
+Error: [postcss] ENOENT: no such file or directory, open './theme/smui-dark.css'
+    at async open (node:internal/fs/promises:636:25)
+    at async Object.readFile (node:internal/fs/promises:1235:14)
+    at async Object.load (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36835:25)
+    at async loadImportContent (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:844:19)
+    at async Promise.all (index 0)
+    at async resolveImportId (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:800:27)
+    at async parseStyles$1 (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:708:5)
+    at async Object.Once (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:965:22)
+    at async LazyResult.runAsync (/app/node_modules/.pnpm/postcss@8.5.8/node_modules/postcss/lib/lazy-result.js:293:11)
+    at async compileCSS (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36898:21)
+Error: [postcss] ENOENT: no such file or directory, open './theme/smui-dark.css'
+    at async open (node:internal/fs/promises:636:25)
+    at async Object.readFile (node:internal/fs/promises:1235:14)
+    at async Object.load (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36835:25)
+    at async loadImportContent (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:844:19)
+    at async Promise.all (index 0)
+    at async resolveImportId (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:800:27)
+    at async parseStyles$1 (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:708:5)
+    at async Object.Once (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:965:22)
+    at async LazyResult.runAsync (/app/node_modules/.pnpm/postcss@8.5.8/node_modules/postcss/lib/lazy-result.js:293:11)
+    at async compileCSS (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36898:21)
+Error: [postcss] ENOENT: no such file or directory, open './theme/smui-dark.css'
+    at async open (node:internal/fs/promises:636:25)
+    at async Object.readFile (node:internal/fs/promises:1235:14)
+    at async Object.load (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36835:25)
+    at async loadImportContent (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:844:19)
+    at async Promise.all (index 0)
+    at async resolveImportId (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:800:27)
+    at async parseStyles$1 (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:708:5)
+    at async Object.Once (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:965:22)
+    at async LazyResult.runAsync (/app/node_modules/.pnpm/postcss@8.5.8/node_modules/postcss/lib/lazy-result.js:293:11)
+    at async compileCSS (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36898:21)
+Error: [postcss] ENOENT: no such file or directory, open './theme/smui-dark.css'
+    at async open (node:internal/fs/promises:636:25)
+    at async Object.readFile (node:internal/fs/promises:1235:14)
+    at async Object.load (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36835:25)
+    at async loadImportContent (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:844:19)
+    at async Promise.all (index 0)
+    at async resolveImportId (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:800:27)
+    at async parseStyles$1 (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:708:5)
+    at async Object.Once (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:965:22)
+    at async LazyResult.runAsync (/app/node_modules/.pnpm/postcss@8.5.8/node_modules/postcss/lib/lazy-result.js:293:11)
+    at async compileCSS (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36898:21)
+Error: [postcss] ENOENT: no such file or directory, open './theme/smui-dark.css'
+    at async open (node:internal/fs/promises:636:25)
+    at async Object.readFile (node:internal/fs/promises:1235:14)
+    at async Object.load (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36835:25)
+    at async loadImportContent (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:844:19)
+    at async Promise.all (index 0)
+    at async resolveImportId (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:800:27)
+    at async parseStyles$1 (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:708:5)
+    at async Object.Once (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:965:22)
+    at async LazyResult.runAsync (/app/node_modules/.pnpm/postcss@8.5.8/node_modules/postcss/lib/lazy-result.js:293:11)
+    at async compileCSS (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36898:21)
+Error: [postcss] ENOENT: no such file or directory, open './theme/smui-dark.css'
+    at async open (node:internal/fs/promises:636:25)
+    at async Object.readFile (node:internal/fs/promises:1235:14)
+    at async Object.load (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36835:25)
+    at async loadImportContent (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:844:19)
+    at async Promise.all (index 0)
+    at async resolveImportId (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:800:27)
+    at async parseStyles$1 (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:708:5)
+    at async Object.Once (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:965:22)
+    at async LazyResult.runAsync (/app/node_modules/.pnpm/postcss@8.5.8/node_modules/postcss/lib/lazy-result.js:293:11)
+    at async compileCSS (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36898:21)

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -39,7 +39,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -59,9 +59,15 @@
 				>
 					<svelte:fragment slot="trailingIcon">
 						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
+							{#if search.length > 0}
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							{:else}
+								<IconButton disabled aria-label="search">
+									<Icon icon="search" />
+								</IconButton>
+							{/if}
 						</div>
 					</svelte:fragment>
 				</Textfield>

--- a/static/~@fontsource/inter/500.css
+++ b/static/~@fontsource/inter/500.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/inter-vietnamese-500-normal.woff2) format('woff2'),
 		url(./files/inter-vietnamese-500-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* inter-latin-ext-500-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/inter-latin-ext-500-normal.woff2) format('woff2'),
 		url(./files/inter-latin-ext-500-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* inter-latin-500-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/inter-latin-500-normal.woff2) format('woff2'),
 		url(./files/inter-latin-500-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/inter/700.css
+++ b/static/~@fontsource/inter/700.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/inter-vietnamese-700-normal.woff2) format('woff2'),
 		url(./files/inter-vietnamese-700-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* inter-latin-ext-700-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/inter-latin-ext-700-normal.woff2) format('woff2'),
 		url(./files/inter-latin-ext-700-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* inter-latin-700-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/inter-latin-700-normal.woff2) format('woff2'),
 		url(./files/inter-latin-700-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/inter/900.css
+++ b/static/~@fontsource/inter/900.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/inter-vietnamese-900-normal.woff2) format('woff2'),
 		url(./files/inter-vietnamese-900-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* inter-latin-ext-900-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/inter-latin-ext-900-normal.woff2) format('woff2'),
 		url(./files/inter-latin-ext-900-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* inter-latin-900-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/inter-latin-900-normal.woff2) format('woff2'),
 		url(./files/inter-latin-900-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/inter/index.css
+++ b/static/~@fontsource/inter/index.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/inter-vietnamese-400-normal.woff2) format('woff2'),
 		url(./files/inter-vietnamese-400-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* inter-latin-ext-400-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/inter-latin-ext-400-normal.woff2) format('woff2'),
 		url(./files/inter-latin-ext-400-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* inter-latin-400-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/inter-latin-400-normal.woff2) format('woff2'),
 		url(./files/inter-latin-400-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/roboto/500.css
+++ b/static/~@fontsource/roboto/500.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/roboto-vietnamese-500-normal.woff2) format('woff2'),
 		url(./files/roboto-vietnamese-500-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* roboto-latin-ext-500-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/roboto-latin-ext-500-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-ext-500-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* roboto-latin-500-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/roboto-latin-500-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-500-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/roboto/700.css
+++ b/static/~@fontsource/roboto/700.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/roboto-vietnamese-700-normal.woff2) format('woff2'),
 		url(./files/roboto-vietnamese-700-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* roboto-latin-ext-700-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/roboto-latin-ext-700-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-ext-700-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* roboto-latin-700-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/roboto-latin-700-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-700-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/roboto/900.css
+++ b/static/~@fontsource/roboto/900.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/roboto-vietnamese-900-normal.woff2) format('woff2'),
 		url(./files/roboto-vietnamese-900-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* roboto-latin-ext-900-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/roboto-latin-ext-900-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-ext-900-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* roboto-latin-900-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/roboto-latin-900-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-900-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/roboto/index.css
+++ b/static/~@fontsource/roboto/index.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/roboto-vietnamese-400-normal.woff2) format('woff2'),
 		url(./files/roboto-vietnamese-400-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* roboto-latin-ext-400-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/roboto-latin-ext-400-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-ext-400-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* roboto-latin-400-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/roboto-latin-400-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-400-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }


### PR DESCRIPTION
💡 What: Replaced the persistent 'cancel' icon on the profile page search bar with a contextual one. Now shows a disabled 'search' icon when empty, and an enabled 'clear' icon when text is entered.
🎯 Why: A persistent 'cancel' icon is misleading when there's nothing to cancel. Showing a search icon indicates what the field does, and swapping to clear only when necessary improves clarity.
♿ Accessibility: Updated `aria-label` dynamically to "search" or "clear search" depending on the state, improving screen reader feedback.

---
*PR created automatically by Jules for task [16772195791374667855](https://jules.google.com/task/16772195791374667855) started by @yeboster*