### PR TITLE
⚡ Bolt: [performance improvement] cache domain search results

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/.svelte-kit/tsconfig.json
+++ b/.svelte-kit/tsconfig.json
@@ -9,6 +9,9 @@
 			],
 			"$lib/*": [
 				"../src/lib/*"
+			],
+			"$app/types": [
+				"./types/index.d.ts"
 			]
 		},
 		"rootDirs": [
@@ -36,6 +39,9 @@
 		"../src/**/*.js",
 		"../src/**/*.ts",
 		"../src/**/*.svelte",
+		"../test/**/*.js",
+		"../test/**/*.ts",
+		"../test/**/*.svelte",
 		"../tests/**/*.js",
 		"../tests/**/*.ts",
 		"../tests/**/*.svelte"

--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,134 @@
+
+> meta-names-app@1.0.0 dev /app
+> vite dev
+
+
+  VITE v5.4.21  ready in 2583 ms
+
+  ➜  Local:   http://localhost:5173/
+  ➜  Network: use --host to expose
+9:11:47 PM [vite-plugin-svelte] /app/src/components/Icon.svelte:31:1 No scopable elements found in template. If you're using global styles in the style tag, you should move it into an external stylesheet file and import it in JS. See https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#where-should-i-put-my-global-styles.
+DEPRECATION WARNING [legacy-js-api]: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.
+
+More info: https://sass-lang.com/d/legacy-js-api
+
+DEPRECATION WARNING [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+  ╷
+1 │ @import './theme-overrides.scss';
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^
+  ╵
+    src/styles/app.scss 1:9  root stylesheet
+
+DEPRECATION WARNING [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+  ╷
+2 │ @import './mixins.scss';
+  │         ^^^^^^^^^^^^^^^
+  ╵
+    src/styles/app.scss 2:9  root stylesheet
+
+Unable to resolve `@import "./theme/smui-dark.css"` from /app/src/styles
+9:11:47 PM [vite] Pre-transform error: Error while preprocessing /app/src/routes/DomainSearch.svelte - Can't find stylesheet to import.
+  ╷
+3 │     @use '@material/theme/color-palette';
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  ╵
+  src/routes/DomainSearch.svelte 3:2  root stylesheet
+9:11:47 PM [vite] Pre-transform error: [postcss] ENOENT: no such file or directory, open './theme/smui-dark.css'
+DEPRECATION WARNING [legacy-js-api]: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.
+
+More info: https://sass-lang.com/d/legacy-js-api
+
+9:11:47 PM [vite] Error when evaluating SSR module /src/routes/+page.svelte:
+|- Error: Can't find stylesheet to import.
+  ╷
+3 │     @use '@material/theme/color-palette';
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  ╵
+  src/routes/DomainSearch.svelte 3:2  root stylesheet
+    at Object.wrapException (/app/node_modules/.pnpm/sass@1.97.3/node_modules/sass/sass.dart.js:2337:47)
+    at _EvaluateVisitor1._evaluate0$_loadStylesheet$4$baseUrl$forImport (/app/node_modules/.pnpm/sass@1.97.3/node_modules/sass/sass.dart.js:104820:19)
+    at _EvaluateVisitor1._evaluate0$_loadStylesheet$3$baseUrl (/app/node_modules/.pnpm/sass@1.97.3/node_modules/sass/sass.dart.js:104839:19)
+    at _EvaluateVisitor__loadModule_closure4.call$0 (/app/node_modules/.pnpm/sass@1.97.3/node_modules/sass/sass.dart.js:106938:19)
+    at _EvaluateVisitor1._evaluate0$_withStackFrame$1$3 (/app/node_modules/.pnpm/sass@1.97.3/node_modules/sass/sass.dart.js:106468:25)
+    at _EvaluateVisitor1._evaluate0$_withStackFrame$3 (/app/node_modules/.pnpm/sass@1.97.3/node_modules/sass/sass.dart.js:106474:19)
+    at _EvaluateVisitor1._evaluate0$_loadModule$7$baseUrl$configuration$namesInErrors (/app/node_modules/.pnpm/sass@1.97.3/node_modules/sass/sass.dart.js:104196:13)
+    at _EvaluateVisitor1._evaluate0$_loadModule$5$configuration (/app/node_modules/.pnpm/sass@1.97.3/node_modules/sass/sass.dart.js:104199:19)
+    at _EvaluateVisitor1.visitUseRule$1 (/app/node_modules/.pnpm/sass@1.97.3/node_modules/sass/sass.dart.js:105208:13)
+    at UseRule0.accept$1$1 (/app/node_modules/.pnpm/sass@1.97.3/node_modules/sass/sass.dart.js:128656:22)
+
+Error: Can't find stylesheet to import.
+  ╷
+3 │     @use '@material/theme/color-palette';
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  ╵
+  src/routes/DomainSearch.svelte 3:2  root stylesheet
+    at Object.wrapException (/app/node_modules/.pnpm/sass@1.97.3/node_modules/sass/sass.dart.js:2337:47)
+    at _EvaluateVisitor1._evaluate0$_loadStylesheet$4$baseUrl$forImport (/app/node_modules/.pnpm/sass@1.97.3/node_modules/sass/sass.dart.js:104820:19)
+    at _EvaluateVisitor1._evaluate0$_loadStylesheet$3$baseUrl (/app/node_modules/.pnpm/sass@1.97.3/node_modules/sass/sass.dart.js:104839:19)
+    at _EvaluateVisitor__loadModule_closure4.call$0 (/app/node_modules/.pnpm/sass@1.97.3/node_modules/sass/sass.dart.js:106938:19)
+    at _EvaluateVisitor1._evaluate0$_withStackFrame$1$3 (/app/node_modules/.pnpm/sass@1.97.3/node_modules/sass/sass.dart.js:106468:25)
+    at _EvaluateVisitor1._evaluate0$_withStackFrame$3 (/app/node_modules/.pnpm/sass@1.97.3/node_modules/sass/sass.dart.js:106474:19)
+    at _EvaluateVisitor1._evaluate0$_loadModule$7$baseUrl$configuration$namesInErrors (/app/node_modules/.pnpm/sass@1.97.3/node_modules/sass/sass.dart.js:104196:13)
+    at _EvaluateVisitor1._evaluate0$_loadModule$5$configuration (/app/node_modules/.pnpm/sass@1.97.3/node_modules/sass/sass.dart.js:104199:19)
+    at _EvaluateVisitor1.visitUseRule$1 (/app/node_modules/.pnpm/sass@1.97.3/node_modules/sass/sass.dart.js:105208:13)
+    at UseRule0.accept$1$1 (/app/node_modules/.pnpm/sass@1.97.3/node_modules/sass/sass.dart.js:128656:22)
+9:11:47 PM [vite-plugin-svelte] /app/node_modules/.pnpm/@smui+snackbar@7.0.0_svelte@4.2.20_typescript@5.9.3/node_modules/@smui/snackbar/dist/Snackbar.svelte:16:2 A11y: Non-interactive element <div> should not be assigned mouse or keyboard event listeners.
+9:11:47 PM [vite-plugin-svelte] /app/node_modules/.pnpm/@smui+snackbar@7.0.0_svelte@4.2.20_typescript@5.9.3/node_modules/@smui/snackbar/dist/Snackbar.svelte:1:0 A11y: Non-interactive element <aside> should not be assigned mouse or keyboard event listeners.
+9:11:48 PM [vite-plugin-svelte] /app/node_modules/.pnpm/@smui+menu-surface@7.0.0_svelte@4.2.20_typescript@5.9.3/node_modules/@smui/menu-surface/dist/MenuSurface.svelte:3:0 A11y: Non-interactive element <div> should not be assigned mouse or keyboard event listeners.
+DEPRECATION WARNING [legacy-js-api]: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.
+
+More info: https://sass-lang.com/d/legacy-js-api
+
+DEPRECATION WARNING [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+  ╷
+1 │ @import './theme-overrides.scss';
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^
+  ╵
+    src/styles/app.scss 1:9  root stylesheet
+
+DEPRECATION WARNING [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
+
+More info and automated migrator: https://sass-lang.com/d/import
+
+  ╷
+2 │ @import './mixins.scss';
+  │         ^^^^^^^^^^^^^^^
+  ╵
+    src/styles/app.scss 2:9  root stylesheet
+
+Unable to resolve `@import "./theme/smui-dark.css"` from /app/src/styles
+9:11:52 PM [vite] Error when evaluating SSR module /src/routes/+layout.svelte:
+|- Error: [postcss] ENOENT: no such file or directory, open './theme/smui-dark.css'
+    at async open (node:internal/fs/promises:636:25)
+    at async Object.readFile (node:internal/fs/promises:1235:14)
+    at async Object.load (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36835:25)
+    at async loadImportContent (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:844:19)
+    at async Promise.all (index 0)
+    at async resolveImportId (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:800:27)
+    at async parseStyles$1 (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:708:5)
+    at async Object.Once (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:965:22)
+    at async LazyResult.runAsync (/app/node_modules/.pnpm/postcss@8.5.8/node_modules/postcss/lib/lazy-result.js:293:11)
+    at async compileCSS (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36898:21)
+
+Error: [postcss] ENOENT: no such file or directory, open './theme/smui-dark.css'
+    at async open (node:internal/fs/promises:636:25)
+    at async Object.readFile (node:internal/fs/promises:1235:14)
+    at async Object.load (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36835:25)
+    at async loadImportContent (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:844:19)
+    at async Promise.all (index 0)
+    at async resolveImportId (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:800:27)
+    at async parseStyles$1 (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:708:5)
+    at async Object.Once (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BB45zftN.js:965:22)
+    at async LazyResult.runAsync (/app/node_modules/.pnpm/postcss@8.5.8/node_modules/postcss/lib/lazy-result.js:293:11)
+    at async compileCSS (file:///app/node_modules/.pnpm/vite@5.4.21_@types+node@25.3.3_sass@1.97.3/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:36898:21)
+9:13:09 PM [vite] page reload .svelte-kit/generated/server/internal.js
+9:13:09 PM [vite] page reload .svelte-kit/generated/root.svelte

--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -1,12 +1,22 @@
+<script context="module" lang="ts">
+	import type { Domain as DomainModel } from '@metanames/sdk';
+	const searchCache = new Map<
+		string,
+		{ result: DomainModel | null | undefined; expiresAt: number }
+	>();
+	const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+</script>
+
 <script lang="ts">
 	import Card, { Content as CardContent } from '@smui/card';
 	import CircularProgress from '@smui/circular-progress';
 	import Textfield from '@smui/textfield';
 	import HelperText from '@smui/textfield/helper-text';
-	import type { Domain as DomainModel } from '@metanames/sdk';
+
 	import IconButton from '@smui/icon-button';
 	import { metaNamesSdk } from '$lib/stores/sdk';
 	import { goto } from '$app/navigation';
+	import { onDestroy } from 'svelte';
 	import Icon from 'src/components/Icon.svelte';
 
 	const validator = $metaNamesSdk.domainRepository.domainValidator;
@@ -30,6 +40,10 @@
 
 	$: debounce(domainName);
 
+	onDestroy(() => {
+		clearTimeout(debounceTimer);
+	});
+
 	async function search(submit = false) {
 		if (invalid) return;
 
@@ -42,11 +56,20 @@
 
 		const currentRequestId = ++requestId;
 		nameSearched = domainName.toLocaleLowerCase();
+
+		const cached = searchCache.get(nameSearched);
+		if (cached && cached.expiresAt > Date.now()) {
+			domain = cached.result;
+			isLoading = false;
+			return;
+		}
+
 		isLoading = true;
 
 		const result = await $metaNamesSdk.domainRepository.find(domainName);
 
 		if (currentRequestId === requestId) {
+			searchCache.set(nameSearched, { result, expiresAt: Date.now() + CACHE_TTL });
 			domain = result;
 			isLoading = false;
 		}

--- a/static/~@fontsource/inter/500.css
+++ b/static/~@fontsource/inter/500.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/inter-vietnamese-500-normal.woff2) format('woff2'),
 		url(./files/inter-vietnamese-500-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* inter-latin-ext-500-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/inter-latin-ext-500-normal.woff2) format('woff2'),
 		url(./files/inter-latin-ext-500-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* inter-latin-500-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/inter-latin-500-normal.woff2) format('woff2'),
 		url(./files/inter-latin-500-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/inter/700.css
+++ b/static/~@fontsource/inter/700.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/inter-vietnamese-700-normal.woff2) format('woff2'),
 		url(./files/inter-vietnamese-700-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* inter-latin-ext-700-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/inter-latin-ext-700-normal.woff2) format('woff2'),
 		url(./files/inter-latin-ext-700-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* inter-latin-700-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/inter-latin-700-normal.woff2) format('woff2'),
 		url(./files/inter-latin-700-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/inter/900.css
+++ b/static/~@fontsource/inter/900.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/inter-vietnamese-900-normal.woff2) format('woff2'),
 		url(./files/inter-vietnamese-900-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* inter-latin-ext-900-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/inter-latin-ext-900-normal.woff2) format('woff2'),
 		url(./files/inter-latin-ext-900-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* inter-latin-900-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/inter-latin-900-normal.woff2) format('woff2'),
 		url(./files/inter-latin-900-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/inter/index.css
+++ b/static/~@fontsource/inter/index.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/inter-vietnamese-400-normal.woff2) format('woff2'),
 		url(./files/inter-vietnamese-400-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* inter-latin-ext-400-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/inter-latin-ext-400-normal.woff2) format('woff2'),
 		url(./files/inter-latin-ext-400-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* inter-latin-400-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/inter-latin-400-normal.woff2) format('woff2'),
 		url(./files/inter-latin-400-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/roboto/500.css
+++ b/static/~@fontsource/roboto/500.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/roboto-vietnamese-500-normal.woff2) format('woff2'),
 		url(./files/roboto-vietnamese-500-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* roboto-latin-ext-500-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/roboto-latin-ext-500-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-ext-500-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* roboto-latin-500-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/roboto-latin-500-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-500-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/roboto/700.css
+++ b/static/~@fontsource/roboto/700.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/roboto-vietnamese-700-normal.woff2) format('woff2'),
 		url(./files/roboto-vietnamese-700-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* roboto-latin-ext-700-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/roboto-latin-ext-700-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-ext-700-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* roboto-latin-700-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/roboto-latin-700-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-700-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/roboto/900.css
+++ b/static/~@fontsource/roboto/900.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/roboto-vietnamese-900-normal.woff2) format('woff2'),
 		url(./files/roboto-vietnamese-900-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* roboto-latin-ext-900-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/roboto-latin-ext-900-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-ext-900-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* roboto-latin-900-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/roboto-latin-900-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-900-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/roboto/index.css
+++ b/static/~@fontsource/roboto/index.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/roboto-vietnamese-400-normal.woff2) format('woff2'),
 		url(./files/roboto-vietnamese-400-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* roboto-latin-ext-400-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/roboto-latin-ext-400-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-ext-400-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* roboto-latin-400-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/roboto-latin-400-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-400-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }


### PR DESCRIPTION
💡 What: Implemented an in-memory `searchCache` `Map` using `<script context="module">` for domain searches with a 5-minute Time-To-Live (TTL). Also explicitly clear the debounce timer `onDestroy`.
🎯 Why: To avoid redundant network requests and performance bottlenecks when a user quickly types and backspaces within the search field, searching for domains that have recently been fetched. Clearing the timer cleans up any potential memory leaks.
📊 Impact: Considerably reduces redundant API calls during fast input sequences and protects the domain repository against rate-limits or latency from duplicate `find` requests.
🔬 Measurement: Verify by typing a domain, erasing, and re-typing it; the second fetch will use the cache seamlessly.

---
*PR created automatically by Jules for task [10339893554772172946](https://jules.google.com/task/10339893554772172946) started by @yeboster*