### PR TITLE
🎨 Palette: Fix incorrect alt text on Ledger Wallet logo image

### DIFF
--- a/src/routes/WalletConnectButton.svelte
+++ b/src/routes/WalletConnectButton.svelte
@@ -134,7 +134,7 @@
 			<Item on:SMUI:action={connectWithLedgerWallet}>
 				<Text>
 					<div class="item">
-						<img class="logo" src={ledgerWalletLogo} alt="partisia wallet logo" />
+						<img class="logo" src={ledgerWalletLogo} alt="ledger wallet logo" />
 						<span>Ledger</span>
 					</div>
 				</Text>


### PR DESCRIPTION
💡 What: Updated the `alt` text attribute on the Ledger wallet logo image from `"partisia wallet logo"` to `"ledger wallet logo"`.

🎯 Why: The incorrect `alt` text provided misleading information to users relying on screen readers. This ensures the alternative text accurately reflects the image it describes.

♿ Accessibility: Improved screen reader experience by providing an accurate description for the Ledger wallet connection option.

---
*PR created automatically by Jules for task [10214599214113677535](https://jules.google.com/task/10214599214113677535) started by @yeboster*