### PR TITLE
⚡ Bolt: Client-side domain search caching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 
 **Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
 **Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.
+
+## 2024-10-25 - Caching vs Tooling Constraints
+**Learning:** SvelteKit auto-generates `.svelte-kit/tsconfig.json` during build/check cycles. Committing this file pollutes the repository and violates the strict "never modify tsconfig" constraint. Additionally, `pnpm install` might generate new lockfiles if dependencies change slightly, which must be reverted.
+**Action:** Always verify `git status` before committing. Use `git restore --staged` and `git checkout` to remove unrequested `.svelte-kit` files and `pnpm-lock.yaml` changes. Keep the PR strictly to the intended performance feature.

--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -1,13 +1,25 @@
+<script context="module" lang="ts">
+	import type { Domain as DomainModel } from '@metanames/sdk';
+
+	interface CacheEntry {
+		result: DomainModel | null;
+		expiresAt: number;
+	}
+
+	const CACHE_TTL_MS = 60000; // 1 minute
+	const searchCache = new Map<string, CacheEntry>();
+</script>
+
 <script lang="ts">
 	import Card, { Content as CardContent } from '@smui/card';
 	import CircularProgress from '@smui/circular-progress';
 	import Textfield from '@smui/textfield';
 	import HelperText from '@smui/textfield/helper-text';
-	import type { Domain as DomainModel } from '@metanames/sdk';
 	import IconButton from '@smui/icon-button';
 	import { metaNamesSdk } from '$lib/stores/sdk';
 	import { goto } from '$app/navigation';
 	import Icon from 'src/components/Icon.svelte';
+	import { onDestroy } from 'svelte';
 
 	const validator = $metaNamesSdk.domainRepository.domainValidator;
 
@@ -30,6 +42,10 @@
 
 	$: debounce(domainName);
 
+	onDestroy(() => {
+		clearTimeout(debounceTimer);
+	});
+
 	async function search(submit = false) {
 		if (invalid) return;
 
@@ -42,11 +58,27 @@
 
 		const currentRequestId = ++requestId;
 		nameSearched = domainName.toLocaleLowerCase();
+
+		// ⚡ Bolt Optimization: Client-side Cache for search results
+		const cacheEntry = searchCache.get(nameSearched);
+		if (cacheEntry && Date.now() < cacheEntry.expiresAt) {
+			if (currentRequestId === requestId) {
+				domain = cacheEntry.result;
+				isLoading = false;
+			}
+			return;
+		}
+
 		isLoading = true;
 
 		const result = await $metaNamesSdk.domainRepository.find(domainName);
 
 		if (currentRequestId === requestId) {
+			searchCache.set(nameSearched, {
+				result,
+				expiresAt: Date.now() + CACHE_TTL_MS
+			});
+
 			domain = result;
 			isLoading = false;
 		}


### PR DESCRIPTION
💡 **What:** Added a client-side `Map` cache to `DomainSearch.svelte` to store recent domain search results. Added `onDestroy` cleanup to clear the debounce timer.
🎯 **Why:** To improve performance by eliminating redundant API calls for domains the user has just searched (e.g., typing "test", deleting back to "t", and typing "test" again). The `onDestroy` prevents memory leaks.
📊 **Impact:** Reduces unnecessary network requests by 100% on repeated queries within the 1-minute TTL.
🔬 **Measurement:** Enter a domain, delete it, and re-enter it. The second query resolves instantly from the cache without triggering a new network fetch via `$metaNamesSdk`.

---
*PR created automatically by Jules for task [11255774718336626655](https://jules.google.com/task/11255774718336626655) started by @yeboster*