### PR TITLE
🎨 Palette: [UX improvement] Add contextual clear icon and inline loading state to DomainSearch

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/.svelte-kit/tsconfig.json
+++ b/.svelte-kit/tsconfig.json
@@ -9,6 +9,9 @@
 			],
 			"$lib/*": [
 				"../src/lib/*"
+			],
+			"$app/types": [
+				"./types/index.d.ts"
 			]
 		},
 		"rootDirs": [
@@ -36,6 +39,9 @@
 		"../src/**/*.js",
 		"../src/**/*.ts",
 		"../src/**/*.svelte",
+		"../test/**/*.js",
+		"../test/**/*.ts",
+		"../test/**/*.svelte",
 		"../tests/**/*.js",
 		"../tests/**/*.ts",
 		"../tests/**/*.svelte"

--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -70,9 +70,32 @@
 		>
 			<svelte:fragment slot="trailingIcon">
 				<div class="submit">
-					<IconButton aria-label="search">
-						<Icon icon="search" />
-					</IconButton>
+					{#if isLoading}
+						<div class="spinner-container" role="status" aria-label="Searching">
+							<CircularProgress style="height: 24px; width: 24px;" indeterminate />
+						</div>
+					{:else if domainName}
+						<div class="actions-container">
+							<IconButton
+								aria-label="clear search"
+								type="button"
+								on:click={() => {
+									domainName = '';
+									domain = undefined;
+									isLoading = false;
+								}}
+							>
+								<Icon icon="clear" />
+							</IconButton>
+							<IconButton aria-label="search" type="submit" disabled={invalid}>
+								<Icon icon="search" />
+							</IconButton>
+						</div>
+					{:else}
+						<IconButton aria-label="search" disabled>
+							<Icon icon="search" />
+						</IconButton>
+					{/if}
 				</div>
 			</svelte:fragment>
 			<svelte:fragment slot="helper">
@@ -82,21 +105,7 @@
 			</svelte:fragment>
 		</Textfield>
 	</form>
-	{#if isLoading}
-		<Card class="domain-link">
-			<CardContent>
-				<div class="card-content">
-					<span>{nameSearchedLabel}</span>
-
-					<CircularProgress
-						style="height: 32px; width: 32px;"
-						indeterminate
-						aria-label="Loading domain search results"
-					/>
-				</div>
-			</CardContent>
-		</Card>
-	{:else if domain}
+	{#if !isLoading && domain}
 		<a class="domain-link" href={`/domain/${domain.name}`}>
 			<Card>
 				<CardContent>
@@ -178,5 +187,18 @@
 
 	.submit {
 		align-self: center;
+	}
+
+	.spinner-container {
+		width: 48px;
+		height: 48px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.actions-container {
+		display: flex;
+		align-items: center;
 	}
 </style>


### PR DESCRIPTION
🎨 Palette: [UX improvement] Add contextual clear icon and inline loading state to DomainSearch

💡 What: Added a 'clear search' icon to the `DomainSearch` input when text is entered, and moved the loading spinner directly into the input's trailing slot.
🎯 Why: Makes it easier to quickly clear searches and retry. Moving the loading spinner into the input prevents sudden, jarring layout shifts when the "loading" card appears and disappears below the form.
📸 Before/After: Visual changes apply to the input field (`src/routes/DomainSearch.svelte`).
♿ Accessibility: The loading spinner now correctly uses `role="status"` and `aria-label="Searching"` within the input context. The clear and search buttons have appropriate `aria-label`s and `type` attributes.

---
*PR created automatically by Jules for task [8660696664355059285](https://jules.google.com/task/8660696664355059285) started by @yeboster*