### PR TITLE
⚡ Bolt: [performance improvement] Cache DomainSearch results

### DIFF
--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -1,9 +1,17 @@
+<script context="module" lang="ts">
+	import type { Domain as DomainModel } from '@metanames/sdk';
+
+	// Cache to prevent redundant network requests across component instances
+	const domainCache = new Map<string, { result: DomainModel | null; timestamp: number }>();
+	const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+</script>
+
 <script lang="ts">
+	import { onDestroy } from 'svelte';
 	import Card, { Content as CardContent } from '@smui/card';
 	import CircularProgress from '@smui/circular-progress';
 	import Textfield from '@smui/textfield';
 	import HelperText from '@smui/textfield/helper-text';
-	import type { Domain as DomainModel } from '@metanames/sdk';
 	import IconButton from '@smui/icon-button';
 	import { metaNamesSdk } from '$lib/stores/sdk';
 	import { goto } from '$app/navigation';
@@ -30,6 +38,10 @@
 
 	$: debounce(domainName);
 
+	onDestroy(() => {
+		clearTimeout(debounceTimer);
+	});
+
 	async function search(submit = false) {
 		if (invalid) return;
 
@@ -41,12 +53,24 @@
 		}
 
 		const currentRequestId = ++requestId;
-		nameSearched = domainName.toLocaleLowerCase();
+		const normalizedDomainName = domainName.toLocaleLowerCase();
+		nameSearched = normalizedDomainName;
+
+		const cached = domainCache.get(normalizedDomainName);
+		if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+			domain = cached.result;
+			isLoading = false;
+			// Increment requestId on cache hits to invalidate any pending network requests from previous inputs
+			requestId++;
+			return;
+		}
+
 		isLoading = true;
 
 		const result = await $metaNamesSdk.domainRepository.find(domainName);
 
 		if (currentRequestId === requestId) {
+			domainCache.set(normalizedDomainName, { result, timestamp: Date.now() });
 			domain = result;
 			isLoading = false;
 		}


### PR DESCRIPTION
💡 **What**: Added an in-memory `Map` cache scoped to the module level in `DomainSearch.svelte`. Results are cached based on the lowercase domain name with a 5-minute TTL. Added cleanup for the debounce timer.

🎯 **Why**: Navigating away from and back to the search page, or re-typing a recently searched domain, previously triggered unnecessary and slow duplicate API calls to the Partisia blockchain backend. By using a `<script context="module">`, the cache survives Svelte component mounts/unmounts.

📊 **Impact**: Reduces redundant network requests for identical domain searches by 100% within a 5-minute window, significantly improving the snappiness of the UI when exploring availability. The `onDestroy` timer cleanup prevents memory leaks.

🔬 **Measurement**: Watch the Network tab. Search for a domain, clear the input, and search for the same domain again. The second search will instantly load from the client-side cache with no API request fired.

---
*PR created automatically by Jules for task [5844224322662968768](https://jules.google.com/task/5844224322662968768) started by @yeboster*