### PR TITLE
🎨 Palette: [UX improvement] - Record.svelte accessibility fixes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,9 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.
+
+## 2025-03-12 - Deterministic Unique IDs for Dialog Accessibility
+
+**Learning:** When using @smui/dialog or similar accessible modal components, especially when rendered in a loop or multiple times on a page (like per-record operations), `aria-labelledby` and `aria-describedby` must point to uniquely generated IDs. Using static IDs like `simple-title` causes screen readers to misidentify modal contexts or read out the wrong accessible names.
+**Action:** Always map generic IDs in reusable accessible components (like `id="simple-title"`) to deterministic, unique values (e.g., `id="confirmation-title-{label}"`) based on specific component props.

--- a/.svelte-kit/tsconfig.json
+++ b/.svelte-kit/tsconfig.json
@@ -9,6 +9,9 @@
 			],
 			"$lib/*": [
 				"../src/lib/*"
+			],
+			"$app/types": [
+				"./types/index.d.ts"
 			]
 		},
 		"rootDirs": [
@@ -36,6 +39,9 @@
 		"../src/**/*.js",
 		"../src/**/*.ts",
 		"../src/**/*.svelte",
+		"../test/**/*.js",
+		"../test/**/*.ts",
+		"../test/**/*.svelte",
 		"../tests/**/*.js",
 		"../tests/**/*.ts",
 		"../tests/**/*.svelte"

--- a/src/components/Record.svelte
+++ b/src/components/Record.svelte
@@ -55,11 +55,11 @@
 <div class="record-container {editMode ? 'edit' : ''}">
 	<Dialog
 		bind:open={dialogOpen}
-		aria-labelledby="confirmation-title"
-		aria-describedby="confirmation-content"
+		aria-labelledby="confirmation-title-{label}"
+		aria-describedby="confirmation-content-{label}"
 	>
-		<Title id="simple-title">Confirm action</Title>
-		<Content id="simple-content">Do you really want to remove the record?</Content>
+		<Title id="confirmation-title-{label}">Confirm action</Title>
+		<Content id="confirmation-content-{label}">Do you really want to remove the record?</Content>
 		<Actions>
 			<Button>
 				<Label>No</Label>
@@ -72,7 +72,7 @@
 	<label for={label}>{label}</label>
 	<div class="value">
 		<Textfield
-			for={label}
+			input$id={label}
 			input$maxlength={maxLength}
 			bind:value={recordValue}
 			bind:invalid

--- a/static/~@fontsource/inter/500.css
+++ b/static/~@fontsource/inter/500.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/inter-vietnamese-500-normal.woff2) format('woff2'),
 		url(./files/inter-vietnamese-500-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* inter-latin-ext-500-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/inter-latin-ext-500-normal.woff2) format('woff2'),
 		url(./files/inter-latin-ext-500-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* inter-latin-500-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/inter-latin-500-normal.woff2) format('woff2'),
 		url(./files/inter-latin-500-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/inter/700.css
+++ b/static/~@fontsource/inter/700.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/inter-vietnamese-700-normal.woff2) format('woff2'),
 		url(./files/inter-vietnamese-700-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* inter-latin-ext-700-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/inter-latin-ext-700-normal.woff2) format('woff2'),
 		url(./files/inter-latin-ext-700-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* inter-latin-700-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/inter-latin-700-normal.woff2) format('woff2'),
 		url(./files/inter-latin-700-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/inter/900.css
+++ b/static/~@fontsource/inter/900.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/inter-vietnamese-900-normal.woff2) format('woff2'),
 		url(./files/inter-vietnamese-900-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* inter-latin-ext-900-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/inter-latin-ext-900-normal.woff2) format('woff2'),
 		url(./files/inter-latin-ext-900-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* inter-latin-900-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/inter-latin-900-normal.woff2) format('woff2'),
 		url(./files/inter-latin-900-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/inter/index.css
+++ b/static/~@fontsource/inter/index.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/inter-vietnamese-400-normal.woff2) format('woff2'),
 		url(./files/inter-vietnamese-400-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* inter-latin-ext-400-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/inter-latin-ext-400-normal.woff2) format('woff2'),
 		url(./files/inter-latin-ext-400-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* inter-latin-400-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/inter-latin-400-normal.woff2) format('woff2'),
 		url(./files/inter-latin-400-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/roboto/500.css
+++ b/static/~@fontsource/roboto/500.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/roboto-vietnamese-500-normal.woff2) format('woff2'),
 		url(./files/roboto-vietnamese-500-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* roboto-latin-ext-500-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/roboto-latin-ext-500-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-ext-500-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* roboto-latin-500-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/roboto-latin-500-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-500-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/roboto/700.css
+++ b/static/~@fontsource/roboto/700.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/roboto-vietnamese-700-normal.woff2) format('woff2'),
 		url(./files/roboto-vietnamese-700-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* roboto-latin-ext-700-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/roboto-latin-ext-700-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-ext-700-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* roboto-latin-700-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/roboto-latin-700-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-700-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/roboto/900.css
+++ b/static/~@fontsource/roboto/900.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/roboto-vietnamese-900-normal.woff2) format('woff2'),
 		url(./files/roboto-vietnamese-900-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* roboto-latin-ext-900-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/roboto-latin-ext-900-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-ext-900-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* roboto-latin-900-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/roboto-latin-900-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-900-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/roboto/index.css
+++ b/static/~@fontsource/roboto/index.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/roboto-vietnamese-400-normal.woff2) format('woff2'),
 		url(./files/roboto-vietnamese-400-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* roboto-latin-ext-400-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/roboto-latin-ext-400-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-ext-400-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* roboto-latin-400-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/roboto-latin-400-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-400-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }


### PR DESCRIPTION
This PR includes two micro-UX/accessibility improvements per the Palette spec. It fixes ID conflicts and improves screen-reader readability for the `<Dialog>` and `<Textfield>` elements inside `src/components/Record.svelte`.

---
*PR created automatically by Jules for task [16210014945727645525](https://jules.google.com/task/16210014945727645525) started by @yeboster*