### PR TITLE
⚡ Bolt: [performance improvement] Prevent array allocation in sort comparator

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,8 @@
 
 **Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
 **Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.
+
+## 2024-11-20 - Array Allocation inside Sort Comparators
+
+**Learning:** Svelte reactive handlers and sorts that use array destructuring and array generation methods (like `.slice()` or `.reverse()`) within an `Array.prototype.sort()` comparator execute on *every comparison* ($O(N \log N)$). This creates massive garbage collection churn and latency for large collections.
+**Action:** Always extract static references or use direct scalar property access with conditional swapping instead of instantiating new arrays inside a sort comparator.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/.svelte-kit/tsconfig.json
+++ b/.svelte-kit/tsconfig.json
@@ -9,6 +9,9 @@
 			],
 			"$lib/*": [
 				"../src/lib/*"
+			],
+			"$app/types": [
+				"./types/index.d.ts"
 			]
 		},
 		"rootDirs": [
@@ -36,6 +39,9 @@
 		"../src/**/*.js",
 		"../src/**/*.ts",
 		"../src/**/*.svelte",
+		"../test/**/*.js",
+		"../test/**/*.ts",
+		"../test/**/*.svelte",
 		"../tests/**/*.js",
 		"../tests/**/*.ts",
 		"../tests/**/*.svelte"

--- a/src/routes/profile/DomainsTable.svelte
+++ b/src/routes/profile/DomainsTable.svelte
@@ -29,9 +29,13 @@
 
 	function handleSort() {
 		domains.sort((a, b) => {
-			const [aVal, bVal] = [a[sort], b[sort]][
-				sortDirection === 'ascending' ? 'slice' : 'reverse'
-			]();
+			// ⚡ Bolt: Prevent array allocation and GC overhead in sort comparator
+			let aVal = a[sort];
+			let bVal = b[sort];
+			if (sortDirection !== 'ascending') {
+				aVal = b[sort];
+				bVal = a[sort];
+			}
 			if (typeof aVal === 'string' && typeof bVal === 'string') return aVal.localeCompare(bVal);
 			return Number(aVal) - Number(bVal);
 		});

--- a/static/~@fontsource/inter/500.css
+++ b/static/~@fontsource/inter/500.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/inter-vietnamese-500-normal.woff2) format('woff2'),
 		url(./files/inter-vietnamese-500-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* inter-latin-ext-500-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/inter-latin-ext-500-normal.woff2) format('woff2'),
 		url(./files/inter-latin-ext-500-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* inter-latin-500-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/inter-latin-500-normal.woff2) format('woff2'),
 		url(./files/inter-latin-500-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/inter/700.css
+++ b/static/~@fontsource/inter/700.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/inter-vietnamese-700-normal.woff2) format('woff2'),
 		url(./files/inter-vietnamese-700-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* inter-latin-ext-700-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/inter-latin-ext-700-normal.woff2) format('woff2'),
 		url(./files/inter-latin-ext-700-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* inter-latin-700-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/inter-latin-700-normal.woff2) format('woff2'),
 		url(./files/inter-latin-700-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/inter/900.css
+++ b/static/~@fontsource/inter/900.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/inter-vietnamese-900-normal.woff2) format('woff2'),
 		url(./files/inter-vietnamese-900-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* inter-latin-ext-900-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/inter-latin-ext-900-normal.woff2) format('woff2'),
 		url(./files/inter-latin-ext-900-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* inter-latin-900-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/inter-latin-900-normal.woff2) format('woff2'),
 		url(./files/inter-latin-900-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/inter/index.css
+++ b/static/~@fontsource/inter/index.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/inter-vietnamese-400-normal.woff2) format('woff2'),
 		url(./files/inter-vietnamese-400-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* inter-latin-ext-400-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/inter-latin-ext-400-normal.woff2) format('woff2'),
 		url(./files/inter-latin-ext-400-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* inter-latin-400-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/inter-latin-400-normal.woff2) format('woff2'),
 		url(./files/inter-latin-400-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/roboto/500.css
+++ b/static/~@fontsource/roboto/500.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/roboto-vietnamese-500-normal.woff2) format('woff2'),
 		url(./files/roboto-vietnamese-500-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* roboto-latin-ext-500-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/roboto-latin-ext-500-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-ext-500-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* roboto-latin-500-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/roboto-latin-500-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-500-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/roboto/700.css
+++ b/static/~@fontsource/roboto/700.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/roboto-vietnamese-700-normal.woff2) format('woff2'),
 		url(./files/roboto-vietnamese-700-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* roboto-latin-ext-700-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/roboto-latin-ext-700-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-ext-700-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* roboto-latin-700-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/roboto-latin-700-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-700-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/roboto/900.css
+++ b/static/~@fontsource/roboto/900.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/roboto-vietnamese-900-normal.woff2) format('woff2'),
 		url(./files/roboto-vietnamese-900-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* roboto-latin-ext-900-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/roboto-latin-ext-900-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-ext-900-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* roboto-latin-900-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/roboto-latin-900-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-900-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/roboto/index.css
+++ b/static/~@fontsource/roboto/index.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/roboto-vietnamese-400-normal.woff2) format('woff2'),
 		url(./files/roboto-vietnamese-400-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* roboto-latin-ext-400-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/roboto-latin-ext-400-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-ext-400-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* roboto-latin-400-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/roboto-latin-400-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-400-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }


### PR DESCRIPTION
💡 What: Prevented unnecessary array instantiation inside the `handleSort` comparator of `DomainsTable.svelte`. Replaced `[a[sort], b[sort]].slice/reverse()` with direct conditional swap using primitive scalar values.

🎯 Why: Generating a new array (via literal instantiation and then `slice`/`reverse`) on every array comparator execution scales disastrously. For an array of size $N$, `Array.prototype.sort` compares values about $O(N \log N)$ times, leading to a huge volume of intermediate arrays filling up the garbage collector and significantly stalling rendering.

📊 Impact: Massively reduces object churn and CPU time by replacing multiple allocations with direct reference swaps. This speeds up large data table sorts noticeably.

🔬 Measurement: Review changes to confirm no array generating calls appear in sort closures and execute sorting logic inside the Domains Table view or unit tests.

---
*PR created automatically by Jules for task [9980246650062341579](https://jules.google.com/task/9980246650062341579) started by @yeboster*