### PR TITLE
⚡ Bolt: Client-side domain search caching

### DIFF
--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -1,9 +1,18 @@
+<script context="module" lang="ts">
+	import type { Domain as DomainModel } from '@metanames/sdk';
+
+	// ⚡ Bolt: Cache search results to prevent redundant API calls for previously queried domains.
+	// Preserved across component unmounts within the module scope.
+	const cache = new Map<string, { result: DomainModel | null; timestamp: number }>();
+	const CACHE_TTL = 5 * 60 * 1000; // 5 minutes TTL to prevent stale data
+</script>
+
 <script lang="ts">
+	import { onDestroy } from 'svelte';
 	import Card, { Content as CardContent } from '@smui/card';
 	import CircularProgress from '@smui/circular-progress';
 	import Textfield from '@smui/textfield';
 	import HelperText from '@smui/textfield/helper-text';
-	import type { Domain as DomainModel } from '@metanames/sdk';
 	import IconButton from '@smui/icon-button';
 	import { metaNamesSdk } from '$lib/stores/sdk';
 	import { goto } from '$app/navigation';
@@ -30,6 +39,11 @@
 
 	$: debounce(domainName);
 
+	// ⚡ Bolt: Prevent memory leaks and reactive state updates on unmounted components
+	onDestroy(() => {
+		clearTimeout(debounceTimer);
+	});
+
 	async function search(submit = false) {
 		if (invalid) return;
 
@@ -42,9 +56,19 @@
 
 		const currentRequestId = ++requestId;
 		nameSearched = domainName.toLocaleLowerCase();
-		isLoading = true;
 
+		const cached = cache.get(nameSearched);
+		if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+			if (currentRequestId === requestId) {
+				domain = cached.result;
+				isLoading = false;
+			}
+			return;
+		}
+
+		isLoading = true;
 		const result = await $metaNamesSdk.domainRepository.find(domainName);
+		cache.set(nameSearched, { result, timestamp: Date.now() });
 
 		if (currentRequestId === requestId) {
 			domain = result;

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -2,5 +2,5 @@ import { expect, test } from '@playwright/test';
 
 test('index page has expected h1', async ({ page }) => {
 	await page.goto('/');
-	await expect(page.getByRole('heading', { name: 'Welcome to SvelteKit' })).toBeVisible();
+	await expect(page.getByRole('heading', { name: 'Find your Meta Name' })).toBeVisible();
 });


### PR DESCRIPTION
💡 What: Implemented a client-side module-scoped `Map` cache for domain typeahead searches with a 5-minute TTL. Added `onDestroy` cleanup for the debounce timer. Updated integration tests.
🎯 Why: Prevents redundant, expensive network API calls for previously queried domains during a user session (especially when typing/backspacing or rapid navigation). Cleaning up the `debounceTimer` prevents memory leaks and state updates on unmounted components.
📊 Impact: Reduces repetitive network calls to the SDK by 100% for cached entries. Decreases latency on cache hits from network speeds to instantaneous O(1) memory retrieval.
🔬 Measurement: Verify cache functionality by typing a domain, clearing it, and typing the same domain again. The second request will bypass the network tab entirely. Ensure the unit tests (`pnpm test:unit --run`) continue to pass.

---
*PR created automatically by Jules for task [4209862319165224862](https://jules.google.com/task/4209862319165224862) started by @yeboster*