### PR TITLE
🎨 Palette: [UX improvement] dynamic profile search input icons

### DIFF
--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -39,7 +39,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		return false;
 	}
 </script>
 
@@ -58,10 +58,16 @@
 					withTrailingIcon
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
+						<div class="icon-container">
+							{#if search.length > 0}
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							{:else}
+								<IconButton aria-label="search" disabled>
+									<Icon icon="search" />
+								</IconButton>
+							{/if}
 						</div>
 					</svelte:fragment>
 				</Textfield>
@@ -88,7 +94,7 @@
 		min-width: 50%;
 	}
 
-	.close-icon {
+	.icon-container {
 		align-self: center;
 		opacity: 0.7;
 	}


### PR DESCRIPTION
💡 What: Conditionally render a disabled 'search' icon when the profile domains search input is empty, and an interactive 'cancel' icon when there is text. Updated class name from `close-icon` to `icon-container` and updated `aria-label` to "clear search".
🎯 Why: To prevent false affordances. A 'cancel' icon when the input is empty implies an action can be taken, whereas a disabled 'search' icon clarifies the input's purpose.
📸 Before/After: Before, a persistent cancel icon was shown. Now, a search icon is shown when empty, switching to cancel when typing.
♿ Accessibility: Updated the `aria-label` on the cancel button from "cancel" to "clear search" to better describe the action to screen reader users. Added a disabled state and `aria-label` to the default search icon.

---
*PR created automatically by Jules for task [17944514964462403856](https://jules.google.com/task/17944514964462403856) started by @yeboster*