### PR TITLE
🎨 Palette: [Dialog ARIA ID accessibility]

### DIFF
--- a/src/components/Record.svelte
+++ b/src/components/Record.svelte
@@ -16,6 +16,7 @@
 	export let repository: RecordRepository;
 	export let editMode = false;
 
+	const dialogId = Math.random().toString(36).substring(2, 9);
 	let recordValue = String(value);
 	let dialogOpen = false;
 
@@ -55,11 +56,11 @@
 <div class="record-container {editMode ? 'edit' : ''}">
 	<Dialog
 		bind:open={dialogOpen}
-		aria-labelledby="confirmation-title"
-		aria-describedby="confirmation-content"
+		aria-labelledby="confirmation-title-{dialogId}"
+		aria-describedby="confirmation-content-{dialogId}"
 	>
-		<Title id="simple-title">Confirm action</Title>
-		<Content id="simple-content">Do you really want to remove the record?</Content>
+		<Title id="confirmation-title-{dialogId}">Confirm action</Title>
+		<Content id="confirmation-content-{dialogId}">Do you really want to remove the record?</Content>
 		<Actions>
 			<Button>
 				<Label>No</Label>


### PR DESCRIPTION
💡 What: Replaced static IDs (`simple-title`, `simple-content`) and duplicate dynamic IDs with a randomly generated unique `dialogId` for the `Dialog`, `Title`, and `Content` components in `Record.svelte`.

🎯 Why: When rendering multiple `Record` components inside a loop on a profile or domain page, they all shared the same DOM IDs. This breaks ARIA label association for screen readers because `aria-labelledby` and `aria-describedby` must reference unique IDs across the entire document.

📸 Before/After: N/A (Internal accessibility fix, visual output remains identical)

♿ Accessibility: Ensures full WCAG compliance for Dialog role elements by properly associating every dialog instance with its specific Title and Description node via correctly bound IDs.

---
*PR created automatically by Jules for task [8191909927323785391](https://jules.google.com/task/8191909927323785391) started by @yeboster*