### PR TITLE
⚡ Bolt: [performance improvement] Implement Domain Search Caching

### DIFF
--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -1,9 +1,19 @@
+<script context="module" lang="ts">
+	import type { Domain as DomainModel } from '@metanames/sdk';
+
+	const domainCache = new Map<
+		string,
+		{ result: DomainModel | null | undefined; timestamp: number }
+	>();
+	const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+</script>
+
 <script lang="ts">
+	import { onDestroy } from 'svelte';
 	import Card, { Content as CardContent } from '@smui/card';
 	import CircularProgress from '@smui/circular-progress';
 	import Textfield from '@smui/textfield';
 	import HelperText from '@smui/textfield/helper-text';
-	import type { Domain as DomainModel } from '@metanames/sdk';
 	import IconButton from '@smui/icon-button';
 	import { metaNamesSdk } from '$lib/stores/sdk';
 	import { goto } from '$app/navigation';
@@ -30,6 +40,10 @@
 
 	$: debounce(domainName);
 
+	onDestroy(() => {
+		clearTimeout(debounceTimer);
+	});
+
 	async function search(submit = false) {
 		if (invalid) return;
 
@@ -42,12 +56,23 @@
 
 		const currentRequestId = ++requestId;
 		nameSearched = domainName.toLocaleLowerCase();
+
+		const cached = domainCache.get(nameSearched);
+		if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+			if (currentRequestId === requestId) {
+				domain = cached.result;
+				isLoading = false;
+			}
+			return;
+		}
+
 		isLoading = true;
 
 		const result = await $metaNamesSdk.domainRepository.find(domainName);
 
 		if (currentRequestId === requestId) {
 			domain = result;
+			domainCache.set(nameSearched, { result, timestamp: Date.now() });
 			isLoading = false;
 		}
 	}


### PR DESCRIPTION
💡 **What:** 
Implemented a module-scoped cache (`Map`) in `DomainSearch.svelte` to store domain availability search results. 
Also added an `onDestroy` hook to clear the input debouncer timer when the component unmounts.

🎯 **Why:** 
The application previously made redundant API calls (`metaNamesSdk.domainRepository.find`) every time a user typed or navigated back to a previously searched domain name. The `onDestroy` hook fixes a potential memory leak where timers could execute after the component was destroyed.

📊 **Impact:** 
Reduces network overhead and API call volume for repeated searches within a 5-minute window (TTL). Prevents state updates on unmounted components.

🔬 **Measurement:** 
Unit tests pass. Can be verified by searching for a domain, clearing the input, and searching for the same domain again within 5 minutes—the second search will resolve instantly without triggering a new network request to the Partisia blockchain.

---
*PR created automatically by Jules for task [6410926975997725254](https://jules.google.com/task/6410926975997725254) started by @yeboster*