### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -1,9 +1,16 @@
+<script context="module" lang="ts">
+	import type { Domain as DomainModel } from '@metanames/sdk';
+
+	const CACHE_TTL = 1000 * 60 * 5; // 5 minutes
+	const domainCache = new Map<string, { domain: DomainModel | null; timestamp: number }>();
+</script>
+
 <script lang="ts">
+	import { onDestroy } from 'svelte';
 	import Card, { Content as CardContent } from '@smui/card';
 	import CircularProgress from '@smui/circular-progress';
 	import Textfield from '@smui/textfield';
 	import HelperText from '@smui/textfield/helper-text';
-	import type { Domain as DomainModel } from '@metanames/sdk';
 	import IconButton from '@smui/icon-button';
 	import { metaNamesSdk } from '$lib/stores/sdk';
 	import { goto } from '$app/navigation';
@@ -17,6 +24,10 @@
 	let isLoading: boolean = false;
 	let debounceTimer: ReturnType<typeof setTimeout>;
 	let requestId = 0;
+
+	onDestroy(() => {
+		clearTimeout(debounceTimer);
+	});
 
 	$: errors = invalid ? validator.getErrors() : [];
 	$: invalid = domainName !== '' && !validator.validate(domainName, { raiseError: false });
@@ -42,11 +53,20 @@
 
 		const currentRequestId = ++requestId;
 		nameSearched = domainName.toLocaleLowerCase();
+
+		const cached = domainCache.get(nameSearched);
+		if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+			domain = cached.domain;
+			isLoading = false;
+			return;
+		}
+
 		isLoading = true;
 
 		const result = await $metaNamesSdk.domainRepository.find(domainName);
 
 		if (currentRequestId === requestId) {
+			domainCache.set(nameSearched, { domain: result || null, timestamp: Date.now() });
 			domain = result;
 			isLoading = false;
 		}


### PR DESCRIPTION
💡 **What**: Implemented a module-level `Map` cache for domain search results in `DomainSearch.svelte` with a 5-minute TTL. Also added an `onDestroy` hook to clear the `debounceTimer`.

🎯 **Why**: Previously, querying the exact same domain multiple times (e.g., typing "test", deleting back to "tes", then typing "test" again) or navigating back to the search page would trigger redundant API calls to the Partisia Blockchain via the SDK. This was inefficient. Additionally, the `debounceTimer` was not being cleaned up, which could lead to state updates on an unmounted component or memory leaks.

📊 **Impact**: Reduces redundant network requests for domain availability checks by serving repeated queries instantly from the client-side cache, creating a snappier user experience. Prevents memory leaks.

🔬 **Measurement**: Verified using a Playwright script that intercepted `window.fetch` calls. Repeated searches for the exact same term (or hitting backspace to return to a previously typed term) correctly skipped the network request and instantly resolved from the local cache. No regressions in type-checking or tests.

---
*PR created automatically by Jules for task [9425110749071517725](https://jules.google.com/task/9425110749071517725) started by @yeboster*