### PR TITLE
⚡ Bolt: [performance improvement] Cache domain searches

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,8 @@
 
 **Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
 **Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.
+
+## 2024-05-23 - Client-side Caching bounded by session duration
+
+**Learning:** Caching bounded by session duration in Svelte applications is best accomplished by using a module-scoped `Map` in `<script context="module">`. This effectively caches repetitive data fetches (like identical user queries) while preventing the cache from growing indefinitely (since it resets on app reload/session end).
+**Action:** Always prefer module-scoped `Map`s for caching over stores if the data doesn't require reactivity to update the UI on change, but rather needs to provide data quickly.

--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -1,9 +1,20 @@
+<script context="module" lang="ts">
+	import type { Domain as DomainModel } from '@metanames/sdk';
+
+	type CacheEntry = {
+		domain: DomainModel | null | undefined;
+		timestamp: number;
+	};
+
+	const searchCache = new Map<string, CacheEntry>();
+	const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+</script>
+
 <script lang="ts">
 	import Card, { Content as CardContent } from '@smui/card';
 	import CircularProgress from '@smui/circular-progress';
 	import Textfield from '@smui/textfield';
 	import HelperText from '@smui/textfield/helper-text';
-	import type { Domain as DomainModel } from '@metanames/sdk';
 	import IconButton from '@smui/icon-button';
 	import { metaNamesSdk } from '$lib/stores/sdk';
 	import { goto } from '$app/navigation';
@@ -42,6 +53,14 @@
 
 		const currentRequestId = ++requestId;
 		nameSearched = domainName.toLocaleLowerCase();
+
+		const cachedItem = searchCache.get(nameSearched);
+		if (cachedItem && Date.now() < cachedItem.timestamp + CACHE_TTL) {
+			domain = cachedItem.domain;
+			isLoading = false;
+			return;
+		}
+
 		isLoading = true;
 
 		const result = await $metaNamesSdk.domainRepository.find(domainName);
@@ -49,6 +68,7 @@
 		if (currentRequestId === requestId) {
 			domain = result;
 			isLoading = false;
+			searchCache.set(nameSearched, { domain, timestamp: Date.now() });
 		}
 	}
 


### PR DESCRIPTION
💡 **What**: Implemented a client-side cache for domain searches using a Svelte module-scoped `Map` in `DomainSearch.svelte`.
🎯 **Why**: When users type, backspace, or repeatedly check the same domains, the app previously triggered identical, expensive API calls (`$metaNamesSdk.domainRepository.find(domainName)`). Caching these results eliminates redundant network requests.
📊 **Impact**: Reduces API calls for repetitive searches by 100% within a 5-minute window (TTL), making the UI feel instantly responsive on cache hits.
🔬 **Measurement**: Search for "test", wait for the result. Clear the input, type "test" again. The result should appear instantly without a network request.

---
*PR created automatically by Jules for task [17610868626420348148](https://jules.google.com/task/17610868626420348148) started by @yeboster*