### PR TITLE
🎨 Palette: [UX improvement] Fix duplicate IDs in Dialog of Record component

### DIFF
--- a/src/components/Record.svelte
+++ b/src/components/Record.svelte
@@ -18,6 +18,7 @@
 
 	let recordValue = String(value);
 	let dialogOpen = false;
+	const dialogId = Math.random().toString(36).substring(2, 9);
 
 	$: label = klass.toString();
 	$: recordClass = getRecordClassFrom(klass);
@@ -55,11 +56,11 @@
 <div class="record-container {editMode ? 'edit' : ''}">
 	<Dialog
 		bind:open={dialogOpen}
-		aria-labelledby="confirmation-title"
-		aria-describedby="confirmation-content"
+			aria-labelledby="confirmation-title-{dialogId}"
+			aria-describedby="confirmation-content-{dialogId}"
 	>
-		<Title id="simple-title">Confirm action</Title>
-		<Content id="simple-content">Do you really want to remove the record?</Content>
+			<Title id="confirmation-title-{dialogId}">Confirm action</Title>
+			<Content id="confirmation-content-{dialogId}">Do you really want to remove the record?</Content>
 		<Actions>
 			<Button>
 				<Label>No</Label>


### PR DESCRIPTION
💡 **What**: Generated unique IDs for `Title` and `Content` sections of the SMUI `Dialog` in `Record.svelte`, linking them properly with `aria-labelledby` and `aria-describedby` using a generated `dialogId`.
🎯 **Why**: When multiple `Record` components are rendered together, they each instantiated a `Dialog` with identical static IDs (`simple-title`, `simple-content`). This breaks HTML uniqueness constraints and causes accessibility issues where screen readers could reference the wrong elements for labeling and description.
♿ **Accessibility**: Prevents duplicate ID conflicts and ensures correct referencing by screen readers via `aria-labelledby` and `aria-describedby` attributes.

---
*PR created automatically by Jules for task [10372727076720569112](https://jules.google.com/task/10372727076720569112) started by @yeboster*