### PR TITLE
🎨 Palette: [UX improvement] Clear redundant alt texts for wallet logos

### DIFF
--- a/src/routes/WalletConnectButton.svelte
+++ b/src/routes/WalletConnectButton.svelte
@@ -118,7 +118,7 @@
 			<Item on:SMUI:action={connectWithMetaMaskWallet}>
 				<Text>
 					<div class="item">
-						<img class="logo" src={metamaskLogo} alt="metamask wallet logo" />
+						<img class="logo" src={metamaskLogo} alt="" />
 						<span>Meta Mask Wallet</span>
 					</div>
 				</Text>
@@ -126,7 +126,7 @@
 			<Item on:SMUI:action={connectWithPartisiaWallet}>
 				<Text>
 					<div class="item">
-						<img class="logo" src={partisiaWalletLogo} alt="partisia wallet logo" />
+						<img class="logo" src={partisiaWalletLogo} alt="" />
 						<span>Partisia Wallet</span>
 					</div>
 				</Text>
@@ -134,7 +134,7 @@
 			<Item on:SMUI:action={connectWithLedgerWallet}>
 				<Text>
 					<div class="item">
-						<img class="logo" src={ledgerWalletLogo} alt="partisia wallet logo" />
+						<img class="logo" src={ledgerWalletLogo} alt="" />
 						<span>Ledger</span>
 					</div>
 				</Text>


### PR DESCRIPTION
💡 What: Set the `alt` text for the wallet logos to empty strings. E.g., `alt=""`.

🎯 Why: The previous implementation had screen readers read out "metamask wallet logo", right before reading the `span` "Meta Mask Wallet" which was redundant. Now it is less repetitive and more accessible for screen reader users.

📸 Before/After: Not a visual change.

♿ Accessibility: Reduced redundant screen reader announcements.

---
*PR created automatically by Jules for task [16086875184132020553](https://jules.google.com/task/16086875184132020553) started by @yeboster*