### PR TITLE
⚡ Bolt: [performance improvement] Execute independent async operations concurrently using Promise.all in getStats

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 
 **Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
 **Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.
+
+## 2024-10-25 - Avoid waterfall in metaNamesSdk
+**Learning:** Sequential await operations involving `metaNamesSdk.domainRepository.count()`, `getOwners()`, and `getRecentDomains()` cause a waterfall latency, especially when communicating with the blockchain context or external services.
+**Action:** Since these fetches are completely independent of each other, group them up and run them concurrently using `Promise.all` to save on round-trips latency and reduce execution time.

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -44,11 +44,13 @@ export interface DomainStats {
 }
 
 export const getStats = async (): Promise<DomainStats> => {
-	const domainCount = await metaNamesSdk.domainRepository.count();
-	const ownerCount = await metaNamesSdk.domainRepository
-		.getOwners()
-		.then((owners) => owners.length);
-	const recentDomains = await getRecentDomains();
+	// ⚡ Bolt: Execute independent async operations concurrently using Promise.all
+	// to avoid waterfall latency and significantly reduce total execution time.
+	const [domainCount, ownerCount, recentDomains] = await Promise.all([
+		metaNamesSdk.domainRepository.count(),
+		metaNamesSdk.domainRepository.getOwners().then((owners) => owners.length),
+		getRecentDomains()
+	]);
 
 	return {
 		domainCount,


### PR DESCRIPTION
💡 What: Replaced sequential `await`s with a concurrent `Promise.all` in `src/lib/server/index.ts` `getStats` method to resolve the waterfall problem.

🎯 Why: The previous implementation sequentially awaited `metaNamesSdk.domainRepository.count()`, `getOwners()`, and `getRecentDomains()`, artificially blocking subsequent independent network requests and adding unnecessary round trip latency.

📊 Impact: Significantly reduces the total latency and execution time for the `getStats` function by executing all independent blockchain and repository data retrieval calls concurrently.
 
🔬 Measurement: Verify locally or synthetically monitor API request latency resolving `/api/stats` endpoint, checking if time to resolve drops relative to sequential wait.

No architectural changes made and code readability is preserved. Tested with the project's internal commands successfully (`pnpm test:unit --run` and `pnpm run check`).

---
*PR created automatically by Jules for task [10071226063095734124](https://jules.google.com/task/10071226063095734124) started by @yeboster*