### PR TITLE
🎨 Palette: Contextual search input icons

### DIFF
--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -39,7 +39,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -59,9 +59,15 @@
 				>
 					<svelte:fragment slot="trailingIcon">
 						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
+							{#if search === ''}
+								<IconButton disabled aria-label="search">
+									<Icon icon="search" />
+								</IconButton>
+							{:else}
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							{/if}
 						</div>
 					</svelte:fragment>
 				</Textfield>


### PR DESCRIPTION
💡 What: Updated the `DomainSearch` input component on the Profile page to switch the trailing icon based on user input state.
🎯 Why: A persistent `cancel` icon gives a false affordance when the search input is empty. Showing a disabled `search` icon provides better context and switching to a functional `cancel` button gives instant visual feedback.
📸 Before/After: Visual changes apply to `src/routes/profile/+page.svelte` trailing search icon.
♿ Accessibility:
- Empty state: Added `disabled` attribute and `aria-label="search"` to clearly indicate state and purpose to screen readers.
- Active state: Added `aria-label="clear search"` to explicitly describe the cancel icon's interaction.

---
*PR created automatically by Jules for task [6476498487096610933](https://jules.google.com/task/6476498487096610933) started by @yeboster*