### PR TITLE
🎨 Palette: [UX improvement] Enhance profile search input with clear icon

### DIFF
--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -59,9 +59,15 @@
 				>
 					<svelte:fragment slot="trailingIcon">
 						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
+							{#if search}
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							{:else}
+								<IconButton disabled aria-label="search">
+									<Icon icon="search" />
+								</IconButton>
+							{/if}
 						</div>
 					</svelte:fragment>
 				</Textfield>


### PR DESCRIPTION
💡 What: The search input in the Profile page now displays a disabled "search" icon when empty, and an interactive "clear" (cancel) icon when text is entered.
🎯 Why: Prevents false affordances by not showing a persistent "cancel" icon when there is nothing to cancel. Provides better visual context to the user about the field's purpose and state.
📸 Before/After: Visual changes only visible to connected wallet users; empty state shows magnifying glass, filled state shows X.
♿ Accessibility: The generic `aria-label="cancel"` was improved to a more descriptive `aria-label="clear search"` for the active clear button, and `aria-label="search"` for the disabled state, improving screen reader context.

---
*PR created automatically by Jules for task [8084094931112082936](https://jules.google.com/task/8084094931112082936) started by @yeboster*