### PR TITLE
⚡ Bolt: [performance improvement] Add domain search caching

### DIFF
--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -1,9 +1,45 @@
+<script context="module" lang="ts">
+	import type { Domain as DomainModel } from '@metanames/sdk';
+
+	const MAX_CACHE_SIZE = 100;
+	const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+	interface CacheEntry {
+		result: DomainModel | null;
+		timestamp: number;
+	}
+
+	const searchCache = new Map<string, CacheEntry>();
+
+	export function getCachedResult(domainName: string): CacheEntry | undefined {
+		const entry = searchCache.get(domainName);
+		if (entry) {
+			if (Date.now() - entry.timestamp > CACHE_TTL) {
+				searchCache.delete(domainName);
+				return undefined;
+			}
+			return entry;
+		}
+		return undefined;
+	}
+
+	export function setCachedResult(domainName: string, result: DomainModel | null) {
+		if (searchCache.size >= MAX_CACHE_SIZE) {
+			const firstKey = searchCache.keys().next().value;
+			if (firstKey) {
+				searchCache.delete(firstKey);
+			}
+		}
+		searchCache.set(domainName, { result, timestamp: Date.now() });
+	}
+</script>
+
 <script lang="ts">
+	import { onDestroy } from 'svelte';
 	import Card, { Content as CardContent } from '@smui/card';
 	import CircularProgress from '@smui/circular-progress';
 	import Textfield from '@smui/textfield';
 	import HelperText from '@smui/textfield/helper-text';
-	import type { Domain as DomainModel } from '@metanames/sdk';
 	import IconButton from '@smui/icon-button';
 	import { metaNamesSdk } from '$lib/stores/sdk';
 	import { goto } from '$app/navigation';
@@ -30,6 +66,10 @@
 
 	$: debounce(domainName);
 
+	onDestroy(() => {
+		clearTimeout(debounceTimer);
+	});
+
 	async function search(submit = false) {
 		if (invalid) return;
 
@@ -42,6 +82,14 @@
 
 		const currentRequestId = ++requestId;
 		nameSearched = domainName.toLocaleLowerCase();
+
+		const cachedResult = getCachedResult(nameSearched);
+		if (cachedResult) {
+			domain = cachedResult.result;
+			isLoading = false;
+			return;
+		}
+
 		isLoading = true;
 
 		const result = await $metaNamesSdk.domainRepository.find(domainName);
@@ -49,6 +97,7 @@
 		if (currentRequestId === requestId) {
 			domain = result;
 			isLoading = false;
+			setCachedResult(nameSearched, result);
 		}
 	}
 


### PR DESCRIPTION
💡 What: Implemented a module-scoped cache in `DomainSearch.svelte` to store search results for up to 5 minutes using a maximum capacity of 100 entries.
🎯 Why: Frequent typings and searches in the `DomainSearch` component often result in duplicated API calls for previously queried domains. Caching avoids these redundant network requests.
📊 Impact: Expected to significantly reduce network load during active typing or re-searching the same string. Re-renders on known items occur near-instantaneously.
🔬 Measurement: Verify using browser dev-tools network tab when re-typing a previously searched domain string. The second query will completely skip the API network call.

---
*PR created automatically by Jules for task [3933241653491141312](https://jules.google.com/task/3933241653491141312) started by @yeboster*