### PR TITLE
🎨 Palette: [UX improvement] - Improve Profile Search Input UX and Ledger Wallet a11y

### DIFF
--- a/src/routes/WalletConnectButton.svelte
+++ b/src/routes/WalletConnectButton.svelte
@@ -134,7 +134,7 @@
 			<Item on:SMUI:action={connectWithLedgerWallet}>
 				<Text>
 					<div class="item">
-						<img class="logo" src={ledgerWalletLogo} alt="partisia wallet logo" />
+						<img class="logo" src={ledgerWalletLogo} alt="ledger wallet logo" />
 						<span>Ledger</span>
 					</div>
 				</Text>

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -39,7 +39,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -59,9 +59,15 @@
 				>
 					<svelte:fragment slot="trailingIcon">
 						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
+							{#if search.length > 0}
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							{:else}
+								<IconButton aria-label="search" disabled>
+									<Icon icon="search" />
+								</IconButton>
+							{/if}
 						</div>
 					</svelte:fragment>
 				</Textfield>


### PR DESCRIPTION
💡 What:
- Updated the Profile search input to conditionally display a disabled "search" icon when empty, and an enabled "cancel" icon with `aria-label="clear search"` when text is present. 
- Corrected the `alt` text for the Ledger wallet logo in `WalletConnectButton.svelte` from "partisia wallet logo" to "ledger wallet logo".
- Fixed a minor bug where `false;` was returned instead of `return false;` in `isFuzzyMatch`.

🎯 Why:
- The persistent "cancel" icon in the search field provided a false affordance when the input was already empty. Replacing it with a contextual search/clear icon improves intuition and aligns with standard UI patterns.
- The incorrect alt text for the Ledger wallet logo was a copy-paste error that harmed accessibility for screen reader users trying to identify the correct wallet to connect.

📸 Before/After:
Before: Search field always showed a clickable "cancel" icon, even when empty.
After: Search field shows a disabled magnifying glass when empty, and swaps to the "cancel" icon when text is entered. 

♿ Accessibility:
- Added `aria-label="clear search"` to the active cancel button.
- Fixed the `alt` text on the Ledger wallet logo for screen readers.

---
*PR created automatically by Jules for task [7666555474532513400](https://jules.google.com/task/7666555474532513400) started by @yeboster*