### PR TITLE
🎨 Palette: [UX improvement] Fix duplicated a11y IDs in Record Dialog

### DIFF
--- a/src/components/Record.svelte
+++ b/src/components/Record.svelte
@@ -6,6 +6,7 @@
 	import Textfield from '@smui/textfield';
 	import Icon from 'src/components/Icon.svelte';
 
+	import { onMount } from 'svelte';
 	import type { RecordRepository } from '@metanames/sdk';
 	import { alertMessage, refresh, walletConnected } from '$lib/stores/main';
 	import { alertTransactionAndFetchResult, getRecordClassFrom, getValidator } from '$lib';
@@ -18,6 +19,11 @@
 
 	let recordValue = String(value);
 	let dialogOpen = false;
+	let dialogId = '';
+
+	onMount(() => {
+		dialogId = Math.random().toString(36).substring(2, 9);
+	});
 
 	$: label = klass.toString();
 	$: recordClass = getRecordClassFrom(klass);
@@ -55,11 +61,11 @@
 <div class="record-container {editMode ? 'edit' : ''}">
 	<Dialog
 		bind:open={dialogOpen}
-		aria-labelledby="confirmation-title"
-		aria-describedby="confirmation-content"
+		aria-labelledby="confirmation-title-{dialogId}"
+		aria-describedby="confirmation-content-{dialogId}"
 	>
-		<Title id="simple-title">Confirm action</Title>
-		<Content id="simple-content">Do you really want to remove the record?</Content>
+		<Title id="confirmation-title-{dialogId}">Confirm action</Title>
+		<Content id="confirmation-content-{dialogId}">Do you really want to remove the record?</Content>
 		<Actions>
 			<Button>
 				<Label>No</Label>


### PR DESCRIPTION
💡 **What**: Dynamically generated unique IDs for the confirmation dialog in `Record.svelte`.
🎯 **Why**: Because `Record` components can be rendered in a list, hardcoded IDs for the dialog's title and content were causing duplicate ID accessibility errors and breaking screen reader associations.
📸 **Before/After**: Visuals remain identical; improvements are strictly related to correct ARIA associations.
♿ **Accessibility**: Resolves duplicate ID violations and ensures screen readers correctly announce the dialog title and content.

---
*PR created automatically by Jules for task [3055824789617018908](https://jules.google.com/task/3055824789617018908) started by @yeboster*