### PR TITLE
⚡ Bolt: [performance improvement] O(N*M) array lookup to O(N+M) Set conversion

### DIFF
--- a/src/routes/api/proposals/voters/add/+server.ts
+++ b/src/routes/api/proposals/voters/add/+server.ts
@@ -23,7 +23,9 @@ export async function GET() {
 			?.setValue()
 			.values.map((voter) => voter.addressValue().value.toString('hex')) ?? [];
 
-	const newVoters = owners.filter((owner) => !voters.includes(owner)).slice(0, 50);
+	// Optimize array lookup from O(N*M) to O(N+M)
+	const votersSet = new Set(voters);
+	const newVoters = owners.filter((owner) => !votersSet.has(owner)).slice(0, 50);
 	if (newVoters.length === 0) return json({ newVoters }, { status: 200 });
 
 	const votingContract = await metaNamesSdk.contractRepository.getContract({

--- a/src/routes/api/proposals/voters/remove/+server.ts
+++ b/src/routes/api/proposals/voters/remove/+server.ts
@@ -25,7 +25,9 @@ export async function GET() {
 			?.setValue()
 			.values.map((voter) => voter.addressValue().value.toString('hex')) ?? [];
 
-	const votersToRemove = voters.filter((voter) => !owners.includes(voter)).slice(0, 50);
+	// Optimize array lookup from O(N*M) to O(N+M)
+	const ownersSet = new Set(owners);
+	const votersToRemove = voters.filter((voter) => !ownersSet.has(voter)).slice(0, 50);
 	if (votersToRemove.length === 0) return json({ newVoters: votersToRemove }, { status: 200 });
 
 	const votingContract = await metaNamesSdk.contractRepository.getContract({


### PR DESCRIPTION
💡 What: Optimized the array lookup in `src/routes/api/proposals/voters/add/+server.ts` and `src/routes/api/proposals/voters/remove/+server.ts` by converting the inner array to a `Set` before filtering.
🎯 Why: The original code used `.includes()` inside a `.filter()` loop, resulting in an $O(N \cdot M)$ time complexity. With thousands of items, this was a significant bottleneck. Converting the inner array to a `Set` first reduces this to $O(N + M)$ time complexity.
📊 Impact: Expected to reduce processing time significantly for large lists of owners and voters. Based on a standalone script, this reduces execution time from ~1.1s down to ~17ms for lists of 50000 and 10000 items.
🔬 Measurement: Verified functionality by running tests (`pnpm test:unit --run`), format (`pnpm run format`), type-checking (`pnpm run check`), and linting (`ESLINT_USE_FLAT_CONFIG=false pnpm lint`). Tests passed successfully.

---
*PR created automatically by Jules for task [13226242221942608273](https://jules.google.com/task/13226242221942608273) started by @yeboster*