### PR TITLE
🎨 Palette: [UX improvement] Add contextual icons to profile search

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+
+## 2024-10-24 - Contextual Icons in Search Inputs
+**Learning:** Using a persistent 'cancel' icon inside a search input gives a false affordance when the input is empty. A better pattern is to show a disabled 'search' icon by default, swapping to an enabled 'clear' icon only when text is present, ensuring appropriate ARIA labels for each state.
+**Action:** Replace static trailing icons in text fields with dynamic icons based on input value to clarify interaction intent and state.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -39,7 +39,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -59,9 +59,15 @@
 				>
 					<svelte:fragment slot="trailingIcon">
 						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
+							{#if search}
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							{:else}
+								<IconButton disabled aria-label="search">
+									<Icon icon="search" />
+								</IconButton>
+							{/if}
 						</div>
 					</svelte:fragment>
 				</Textfield>


### PR DESCRIPTION
💡 **What:** Replaced the persistent "cancel" icon in the profile page search bar (`src/routes/profile/+page.svelte`) with contextual icons: a disabled "search" magnifying glass when the input is empty, and an enabled "clear search" icon when text is present.

🎯 **Why:** The previous design provided a false affordance; showing a "cancel" icon when there was nothing to cancel or clear was confusing. The new design clarifies the interaction intent by showing that the input is meant for searching, and dynamically provides the clear action only when it is applicable.

📸 **Before/After:**
*(Before)* The input always showed an active "cancel" icon regardless of state.
*(After)* The input shows a grayed-out "search" icon by default. Typing into the input swaps it to an active "cancel" (clear) icon.

♿ **Accessibility:** Updated the `aria-label`s to accurately reflect the icon's current purpose (`aria-label="search"` vs `aria-label="clear search"`). This ensures screen reader users are not confused by a static "cancel" label.

---
*PR created automatically by Jules for task [6898858476240216687](https://jules.google.com/task/6898858476240216687) started by @yeboster*