### PR TITLE
⚡ Bolt: [performance improvement] Cache domain searches

### DIFF
--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -1,9 +1,37 @@
+<script context="module" lang="ts">
+	import type { Domain as DomainModel } from '@metanames/sdk';
+
+	const searchCache = new Map<string, { domain: DomainModel | null; expiresAt: number }>();
+	const MAX_CACHE_SIZE = 100;
+	const CACHE_TTL = 60000; // 1 minute
+
+	function getCachedDomain(name: string): DomainModel | null | undefined {
+		const cached = searchCache.get(name);
+		if (cached && cached.expiresAt > Date.now()) {
+			return cached.domain;
+		}
+		if (cached) {
+			searchCache.delete(name); // Remove stale entry
+		}
+		return undefined;
+	}
+
+	function setCachedDomain(name: string, domain: DomainModel | null) {
+		if (searchCache.size >= MAX_CACHE_SIZE) {
+			// FIFO eviction: remove the first item
+			const firstKey = searchCache.keys().next().value;
+			if (firstKey !== undefined) searchCache.delete(firstKey);
+		}
+		searchCache.set(name, { domain, expiresAt: Date.now() + CACHE_TTL });
+	}
+</script>
+
 <script lang="ts">
+	import { onDestroy } from 'svelte';
 	import Card, { Content as CardContent } from '@smui/card';
 	import CircularProgress from '@smui/circular-progress';
 	import Textfield from '@smui/textfield';
 	import HelperText from '@smui/textfield/helper-text';
-	import type { Domain as DomainModel } from '@metanames/sdk';
 	import IconButton from '@smui/icon-button';
 	import { metaNamesSdk } from '$lib/stores/sdk';
 	import { goto } from '$app/navigation';
@@ -30,6 +58,10 @@
 
 	$: debounce(domainName);
 
+	onDestroy(() => {
+		clearTimeout(debounceTimer);
+	});
+
 	async function search(submit = false) {
 		if (invalid) return;
 
@@ -42,12 +74,23 @@
 
 		const currentRequestId = ++requestId;
 		nameSearched = domainName.toLocaleLowerCase();
+
+		const cachedResult = getCachedDomain(nameSearched);
+		if (cachedResult !== undefined) {
+			if (currentRequestId === requestId) {
+				domain = cachedResult;
+				isLoading = false;
+			}
+			return;
+		}
+
 		isLoading = true;
 
 		const result = await $metaNamesSdk.domainRepository.find(domainName);
 
 		if (currentRequestId === requestId) {
 			domain = result;
+			setCachedDomain(nameSearched, result);
 			isLoading = false;
 		}
 	}


### PR DESCRIPTION
💡 **What:** 
- Added a `<script context="module">` block to `DomainSearch.svelte` to implement an in-memory `Map` cache for search queries.
- Implemented a 1-minute TTL and a maximum cache size of 100 with FIFO eviction to prevent memory leaks over time.
- Updated the `search` function to hit the cache first before performing an SDK lookup.
- Added an `onDestroy` hook to clean up the `debounceTimer` and prevent component memory leaks upon unmounting.

🎯 **Why:** 
When users type in the domain search box, they frequently type and backspace, resulting in redundant network requests for domains they have just searched for. The `debounce` logic handles fast typing, but caching eliminates the API call entirely if they return to a previous state. 

📊 **Impact:** 
- Completely eliminates redundant network requests for previously searched queries within a 1-minute window.
- Eliminates potential memory leaks caused by lingering debouncer timeouts after the component unmounts.

🔬 **Measurement:** 
- Run the local dev server and open the Network tab. Search for "test", wait for the result, type "tests", wait for the result, and then backspace to "test". You will see that the network request for the second "test" search is not fired, but the UI updates immediately.

---
*PR created automatically by Jules for task [5788307772188944389](https://jules.google.com/task/5788307772188944389) started by @yeboster*