### PR TITLE
🎨 Palette: [UX improvement] Improve search input clear behavior

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -39,7 +39,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -59,9 +59,15 @@
 				>
 					<svelte:fragment slot="trailingIcon">
 						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
+							{#if search !== ''}
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							{:else}
+								<IconButton aria-label="search" disabled>
+									<Icon icon="search" />
+								</IconButton>
+							{/if}
 						</div>
 					</svelte:fragment>
 				</Textfield>


### PR DESCRIPTION
🎨 Palette: [UX improvement] Improve search input clear behavior

💡 What: Changed the static "cancel" icon in the profile search bar to be conditional. It now shows a disabled "search" icon when empty, and an interactive "clear search" (cancel) icon only when there is text to clear.
🎯 Why: Prevents the false affordance of a clear button when there's nothing to clear, and provides a visual hint that the field is for searching when empty.
♿ Accessibility: Added `aria-label="clear search"` to the active clear button and `disabled` state with `aria-label="search"` to the empty state icon.

---
*PR created automatically by Jules for task [17884907527382560446](https://jules.google.com/task/17884907527382560446) started by @yeboster*