### PR TITLE
⚡ Bolt: Cache domain search results

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/.svelte-kit/tsconfig.json
+++ b/.svelte-kit/tsconfig.json
@@ -9,6 +9,9 @@
 			],
 			"$lib/*": [
 				"../src/lib/*"
+			],
+			"$app/types": [
+				"./types/index.d.ts"
 			]
 		},
 		"rootDirs": [
@@ -36,6 +39,9 @@
 		"../src/**/*.js",
 		"../src/**/*.ts",
 		"../src/**/*.svelte",
+		"../test/**/*.js",
+		"../test/**/*.ts",
+		"../test/**/*.svelte",
 		"../tests/**/*.js",
 		"../tests/**/*.ts",
 		"../tests/**/*.svelte"

--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -1,9 +1,17 @@
+<script context="module" lang="ts">
+	import type { Domain as DomainModel } from '@metanames/sdk';
+
+	const MAX_CACHE_SIZE = 100;
+	const CACHE_TTL_MS = 60000;
+	const searchCache = new Map<string, { data: DomainModel | null; timestamp: number }>();
+</script>
+
 <script lang="ts">
+	import { onDestroy } from 'svelte';
 	import Card, { Content as CardContent } from '@smui/card';
 	import CircularProgress from '@smui/circular-progress';
 	import Textfield from '@smui/textfield';
 	import HelperText from '@smui/textfield/helper-text';
-	import type { Domain as DomainModel } from '@metanames/sdk';
 	import IconButton from '@smui/icon-button';
 	import { metaNamesSdk } from '$lib/stores/sdk';
 	import { goto } from '$app/navigation';
@@ -30,6 +38,10 @@
 
 	$: debounce(domainName);
 
+	onDestroy(() => {
+		clearTimeout(debounceTimer);
+	});
+
 	async function search(submit = false) {
 		if (invalid) return;
 
@@ -44,7 +56,25 @@
 		nameSearched = domainName.toLocaleLowerCase();
 		isLoading = true;
 
-		const result = await $metaNamesSdk.domainRepository.find(domainName);
+		let result: DomainModel | null | undefined;
+		const now = Date.now();
+		const cached = searchCache.get(nameSearched);
+
+		if (cached && now - cached.timestamp < CACHE_TTL_MS) {
+			result = cached.data;
+		} else {
+			result = await $metaNamesSdk.domainRepository.find(domainName);
+
+			if (result !== undefined) {
+				if (searchCache.size >= MAX_CACHE_SIZE) {
+					const firstKey = searchCache.keys().next().value;
+					if (firstKey !== undefined) {
+						searchCache.delete(firstKey);
+					}
+				}
+				searchCache.set(nameSearched, { data: result, timestamp: now });
+			}
+		}
 
 		if (currentRequestId === requestId) {
 			domain = result;

--- a/static/~@fontsource/inter/500.css
+++ b/static/~@fontsource/inter/500.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/inter-vietnamese-500-normal.woff2) format('woff2'),
 		url(./files/inter-vietnamese-500-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* inter-latin-ext-500-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/inter-latin-ext-500-normal.woff2) format('woff2'),
 		url(./files/inter-latin-ext-500-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* inter-latin-500-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/inter-latin-500-normal.woff2) format('woff2'),
 		url(./files/inter-latin-500-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/inter/700.css
+++ b/static/~@fontsource/inter/700.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/inter-vietnamese-700-normal.woff2) format('woff2'),
 		url(./files/inter-vietnamese-700-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* inter-latin-ext-700-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/inter-latin-ext-700-normal.woff2) format('woff2'),
 		url(./files/inter-latin-ext-700-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* inter-latin-700-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/inter-latin-700-normal.woff2) format('woff2'),
 		url(./files/inter-latin-700-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/inter/900.css
+++ b/static/~@fontsource/inter/900.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/inter-vietnamese-900-normal.woff2) format('woff2'),
 		url(./files/inter-vietnamese-900-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* inter-latin-ext-900-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/inter-latin-ext-900-normal.woff2) format('woff2'),
 		url(./files/inter-latin-ext-900-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* inter-latin-900-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/inter-latin-900-normal.woff2) format('woff2'),
 		url(./files/inter-latin-900-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/inter/index.css
+++ b/static/~@fontsource/inter/index.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/inter-vietnamese-400-normal.woff2) format('woff2'),
 		url(./files/inter-vietnamese-400-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* inter-latin-ext-400-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/inter-latin-ext-400-normal.woff2) format('woff2'),
 		url(./files/inter-latin-ext-400-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* inter-latin-400-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/inter-latin-400-normal.woff2) format('woff2'),
 		url(./files/inter-latin-400-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/roboto/500.css
+++ b/static/~@fontsource/roboto/500.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/roboto-vietnamese-500-normal.woff2) format('woff2'),
 		url(./files/roboto-vietnamese-500-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* roboto-latin-ext-500-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/roboto-latin-ext-500-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-ext-500-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* roboto-latin-500-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/roboto-latin-500-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-500-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/roboto/700.css
+++ b/static/~@fontsource/roboto/700.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/roboto-vietnamese-700-normal.woff2) format('woff2'),
 		url(./files/roboto-vietnamese-700-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* roboto-latin-ext-700-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/roboto-latin-ext-700-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-ext-700-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* roboto-latin-700-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/roboto-latin-700-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-700-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/roboto/900.css
+++ b/static/~@fontsource/roboto/900.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/roboto-vietnamese-900-normal.woff2) format('woff2'),
 		url(./files/roboto-vietnamese-900-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* roboto-latin-ext-900-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/roboto-latin-ext-900-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-ext-900-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* roboto-latin-900-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/roboto-latin-900-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-900-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/static/~@fontsource/roboto/index.css
+++ b/static/~@fontsource/roboto/index.css
@@ -55,8 +55,9 @@
 	src:
 		url(./files/roboto-vietnamese-400-normal.woff2) format('woff2'),
 		url(./files/roboto-vietnamese-400-normal.woff) format('woff');
-	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0,
-		U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+	unicode-range:
+		U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+		U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }
 
 /* roboto-latin-ext-400-normal */
@@ -68,8 +69,9 @@
 	src:
 		url(./files/roboto-latin-ext-400-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-ext-400-normal.woff) format('woff');
-	unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB,
-		U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF,
+		U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* roboto-latin-400-normal */
@@ -81,7 +83,7 @@
 	src:
 		url(./files/roboto-latin-400-normal.woff2) format('woff2'),
 		url(./files/roboto-latin-400-normal.woff) format('woff');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }


### PR DESCRIPTION
💡 What: Implemented a persistent module-scoped `Map` cache for domain search results in `src/routes/DomainSearch.svelte`.

🎯 Why: To prevent redundant network requests to `$metaNamesSdk.domainRepository.find` for domains that have already been searched.

📊 Impact: Reduces repetitive search API calls to 0 within the cache TTL, providing instant feedback for previously searched domains. This optimization also implements a fixed maximum cache size (100 elements) and TTL (60s) to prevent server-side memory leaks.

🔬 Measurement: Verify by searching for a domain, clearing the input, and searching for it again; the second lookup should resolve instantly without a network request.

Also fixed a potential client-side memory leak by explicitly clearing the `debounceTimer` in the `onDestroy` lifecycle hook.

---
*PR created automatically by Jules for task [12896148263387518486](https://jules.google.com/task/12896148263387518486) started by @yeboster*