### PR TITLE
🎨 Palette: [UX improvement] Contextual search input icons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,8 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+
+## 2024-10-25 - Contextual Icons in Search Inputs
+
+**Learning:** Using a persistent 'cancel' icon in search inputs when no text is present creates a false affordance.
+**Action:** When implementing search inputs, use contextual icons (e.g., a disabled 'search' magnifying glass when empty, and an enabled 'clear' icon when text is present) rather than a persistent 'cancel' icon to prevent false affordances. Ensure `aria-label`s reflect the active icon's purpose (e.g., `aria-label="clear search"`).

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -59,9 +59,15 @@
 				>
 					<svelte:fragment slot="trailingIcon">
 						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
+							{#if search}
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							{:else}
+								<IconButton disabled aria-label="search">
+									<Icon icon="search" />
+								</IconButton>
+							{/if}
 						</div>
 					</svelte:fragment>
 				</Textfield>


### PR DESCRIPTION
💡 **What**: Replaced the persistent "cancel" icon in the search input on the profile page with a contextual icon. When the input is empty, it displays a disabled "search" magnifying glass. When the user enters text, it transitions to a functional "clear search" button.
🎯 **Why**: A "cancel" icon in an empty text field creates a false affordance, leading users to believe there is something to cancel. Showing a "search" icon better indicates the input's purpose, and a "clear" icon when populated offers an expected path to reset the field.
♿ **Accessibility**: Replaced `aria-label="cancel"` with `aria-label="clear search"` for improved screen reader context, and added `aria-label="search"` on the disabled search icon.

---
*PR created automatically by Jules for task [10225435357400405895](https://jules.google.com/task/10225435357400405895) started by @yeboster*