### PR TITLE
🎨 Palette: [UX improvement] Add aria-label to Chip buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/src/components/Chip.svelte
+++ b/src/components/Chip.svelte
@@ -28,7 +28,12 @@
 	export { className as class };
 </script>
 
-<Button on:click={action} variant="outlined" class={`chip ${className || ''}`}>
+<Button
+	on:click={action}
+	variant="outlined"
+	class={`chip ${className || ''}`}
+	aria-label={type === 'url' ? 'Open link ' + label : 'Copy ' + label}
+>
 	<Label>
 		<div class="container">
 			<span class="label">{label}</span>


### PR DESCRIPTION
💡 What: Added dynamic `aria-label` to the `Button` component inside `Chip.svelte`.
🎯 Why: Icon-only or ambiguously labeled actions (like a chip with just text and an icon) lack proper context for screen reader users. The dynamic label clarifies whether the action will "Open link" or "Copy" the value.
📸 Before/After: Visuals remain unchanged; the improvement is strictly accessible text.
♿ Accessibility: Improves screen reader context for `Chip` actions by making the button purpose explicit instead of relying solely on the visual icon or inner text.

---
*PR created automatically by Jules for task [8791508461331968440](https://jules.google.com/task/8791508461331968440) started by @yeboster*