### PR TITLE
🎨 Palette: [UX improvement] Contextual Icons for Profile Search

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,8 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+
+## 2024-10-24 - Contextual Icons in Search Inputs
+
+**Learning:** Using a persistent "cancel" icon in search inputs when there is no text provides a false affordance. It can confuse users who expect it to be a submit button. Also, the `aria-label` must accurately reflect the action ("clear search" instead of "cancel").
+**Action:** Always implement contextual icons in search inputs: a disabled magnifying glass "search" icon when empty, which switches to an enabled "clear" icon when text is present. Ensure `aria-label` is updated accordingly.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -59,9 +59,15 @@
 				>
 					<svelte:fragment slot="trailingIcon">
 						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
+							{#if search === ''}
+								<IconButton disabled aria-label="search">
+									<Icon icon="search" />
+								</IconButton>
+							{:else}
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							{/if}
 						</div>
 					</svelte:fragment>
 				</Textfield>


### PR DESCRIPTION
💡 **What:** Replaced the persistent "cancel" icon in the profile domains search input with contextual icons. When the input is empty, it displays a disabled "search" magnifying glass. When the user types, it switches to a functional "cancel" icon.
🎯 **Why:** A persistent "cancel" icon in an empty search field provides a false affordance, leading users to mistakenly believe it is a submit button. Contextual icons provide immediate visual clarity about the field's current state and intended action.
📸 **Before/After:** Before, a cancel icon always displayed. After, a disabled search icon displays when empty, switching to clear when text is entered.
♿ **Accessibility:** Updated the `aria-label` on the cancel action from generic "cancel" to the more descriptive "clear search", improving screen reader clarity.

---
*PR created automatically by Jules for task [7463475529137876123](https://jules.google.com/task/7463475529137876123) started by @yeboster*