### PR TITLE
🎨 Palette: [UX improvement] Fix duplicate Dialog IDs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/.svelte-kit/tsconfig.json
+++ b/.svelte-kit/tsconfig.json
@@ -9,6 +9,9 @@
 			],
 			"$lib/*": [
 				"../src/lib/*"
+			],
+			"$app/types": [
+				"./types/index.d.ts"
 			]
 		},
 		"rootDirs": [
@@ -25,7 +28,10 @@
 		"moduleResolution": "bundler",
 		"module": "esnext",
 		"noEmit": true,
-		"target": "esnext"
+		"target": "esnext",
+		"types": [
+			"node"
+		]
 	},
 	"include": [
 		"ambient.d.ts",
@@ -36,6 +42,9 @@
 		"../src/**/*.js",
 		"../src/**/*.ts",
 		"../src/**/*.svelte",
+		"../test/**/*.js",
+		"../test/**/*.ts",
+		"../test/**/*.svelte",
 		"../tests/**/*.js",
 		"../tests/**/*.ts",
 		"../tests/**/*.svelte"

--- a/src/components/Record.svelte
+++ b/src/components/Record.svelte
@@ -6,6 +6,7 @@
 	import Textfield from '@smui/textfield';
 	import Icon from 'src/components/Icon.svelte';
 
+	import { onMount } from 'svelte';
 	import type { RecordRepository } from '@metanames/sdk';
 	import { alertMessage, refresh, walletConnected } from '$lib/stores/main';
 	import { alertTransactionAndFetchResult, getRecordClassFrom, getValidator } from '$lib';
@@ -31,6 +32,11 @@
 	$: maxLength = 'maxLength' in validator.rules ? (validator.rules['maxLength'] as number) : 64;
 
 	let edit = false;
+	let dialogId = '';
+
+	onMount(() => {
+		dialogId = Math.random().toString(36).substring(2, 9);
+	});
 
 	function toggleEdit(restore = true) {
 		edit = !edit;
@@ -55,11 +61,11 @@
 <div class="record-container {editMode ? 'edit' : ''}">
 	<Dialog
 		bind:open={dialogOpen}
-		aria-labelledby="confirmation-title"
-		aria-describedby="confirmation-content"
+		aria-labelledby="confirmation-title-{dialogId}"
+		aria-describedby="confirmation-content-{dialogId}"
 	>
-		<Title id="simple-title">Confirm action</Title>
-		<Content id="simple-content">Do you really want to remove the record?</Content>
+		<Title id="confirmation-title-{dialogId}">Confirm action</Title>
+		<Content id="confirmation-content-{dialogId}">Do you really want to remove the record?</Content>
 		<Actions>
 			<Button>
 				<Label>No</Label>


### PR DESCRIPTION
💡 What: Generated unique IDs for Dialogs inside `Record.svelte`.
🎯 Why: Resolves duplicate DOM `id` issues when multiple instances of `RecordComponent` render simultaneously in the UI, which previously caused screen readers to malfunction due to overlapping ARIA IDs.
♿ Accessibility: `aria-labelledby` and `aria-describedby` now reliably point to unique `<Title>` and `<Content>` IDs across instances.

---
*PR created automatically by Jules for task [4036546527598821841](https://jules.google.com/task/4036546527598821841) started by @yeboster*