### PR TITLE
🎨 Palette: [UX improvement] Contextual search icons on Profile page

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,8 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+
+## 2026-04-09 - Contextual Search Icons
+
+**Learning:** Showing a 'clear' icon in an empty search input creates a false affordance, as there's nothing to clear. This can cause user confusion.
+**Action:** Use contextual icons (e.g., a disabled 'search' magnifying glass when empty, and an enabled 'clear' icon when text is present) in search inputs to provide accurate interaction cues and prevent false affordances. Ensure `aria-label`s reflect the active icon's purpose.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -59,9 +59,15 @@
 				>
 					<svelte:fragment slot="trailingIcon">
 						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
+							{#if search !== ''}
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							{:else}
+								<IconButton disabled aria-label="search">
+									<Icon icon="search" />
+								</IconButton>
+							{/if}
 						</div>
 					</svelte:fragment>
 				</Textfield>


### PR DESCRIPTION
**💡 What:** 
Updated the search input in the Profile page (`src/routes/profile/+page.svelte`) to use a contextual trailing icon. It now displays a disabled search magnifying glass when empty, and an enabled "clear" cancel icon when there is text to clear.

**🎯 Why:**
Showing a 'clear' icon in an empty search input creates a false affordance, as there is nothing to clear. This can cause user confusion. Replacing it with a disabled search icon provides accurate interaction cues while maintaining the UI layout structure.

**📸 Before/After:**
*(Visual changes verified via internal test render)*
Before: Empty search input showed a clickable "cancel" icon.
After: Empty search input shows a disabled "search" icon. Typing text changes it to an active "cancel" icon.

**♿ Accessibility:**
Updated `aria-label` attributes to accurately reflect the active icon's purpose ("clear search" vs "search"), ensuring screen readers provide correct context.

---
*PR created automatically by Jules for task [3086641372088216297](https://jules.google.com/task/3086641372088216297) started by @yeboster*