### PR TITLE
🎨 Palette: Contextual Icons for Profile Search

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.
+## 2026-04-10 - Contextual Search Icons
+**Learning:** When implementing search inputs, use contextual icons (e.g., a disabled 'search' magnifying glass when empty, and an enabled 'clear' icon when text is present) rather than a persistent 'cancel' icon to prevent false affordances. Ensure `aria-label`s reflect the active icon's purpose.
+**Action:** Always conditionally render search input icons based on the input's state and verify ARIA labels match the current icon's function.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -59,9 +59,15 @@
 				>
 					<svelte:fragment slot="trailingIcon">
 						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
+							{#if search}
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							{:else}
+								<IconButton disabled aria-label="search">
+									<Icon icon="search" />
+								</IconButton>
+							{/if}
 						</div>
 					</svelte:fragment>
 				</Textfield>


### PR DESCRIPTION
💡 **What**: Replaced the persistent 'cancel' icon on the profile page's domain search input with a contextual set of icons (disabled 'search' icon when empty, active 'cancel' clear icon when text is present).
🎯 **Why**: To prevent false affordances and improve UX. Users shouldn't be presented with an active 'cancel' button when there is nothing to cancel.
📸 **Before/After**: Visually verified via isolated Playwright static HTML mockups.
♿ **Accessibility**: Added distinct `aria-label`s for the different icon states (`aria-label="search"` vs `aria-label="clear search"`) to ensure correct screen reader announcements.

---
*PR created automatically by Jules for task [5630464689220910303](https://jules.google.com/task/5630464689220910303) started by @yeboster*