### PR TITLE
🎨 Palette: [UX improvement] Contextual Search Icon

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.
+## 2024-04-11 - Search Input Icon Affordance
+**Learning:** In the profile search component, displaying a persistent "cancel" (clear) icon when the input is empty creates a false affordance.
+**Action:** Replaced the persistent clear icon with a contextual one: it displays a disabled search magnifying glass when empty, and an interactive "clear search" icon when text is present. Added proper `aria-label`s to both.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -39,7 +39,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -59,9 +59,15 @@
 				>
 					<svelte:fragment slot="trailingIcon">
 						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
+							{#if search === ''}
+								<IconButton disabled aria-label="search">
+									<Icon icon="search" />
+								</IconButton>
+							{:else}
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							{/if}
 						</div>
 					</svelte:fragment>
 				</Textfield>


### PR DESCRIPTION
💡 **What:** Replaced the persistent "cancel" icon in the profile search input with a dynamic contextual icon.
🎯 **Why:** Having a "clear" button visible when an input is empty creates a false affordance. Showing a disabled search icon provides a better visual hint, while swapping to a clear icon when text is present makes the interface more intuitive.
📸 **Before/After:** The icon now switches dynamically between `search` (empty) and `cancel` (filled).
♿ **Accessibility:** Added `aria-label="clear search"` to the active button and `aria-label="search"` to the disabled visual indicator, improving screen reader context.

---
*PR created automatically by Jules for task [3834031777248687805](https://jules.google.com/task/3834031777248687805) started by @yeboster*