### PR TITLE
⚡ Bolt: [performance improvement] Concurrent stats fetching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,8 @@
 
 **Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
 **Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.
+
+## 2024-04-14 - Concurrent stats fetching
+
+**Learning:** When fetching multiple independent statistics (like domain counts and recent domains), sequential await statements cause the total response time to be the sum of all requests. Using `Promise.all` allows these requests to execute concurrently, reducing the total time to the longest single request.
+**Action:** Always look for sequential await statements that don't depend on each other's results and refactor them to use `Promise.all` for better concurrency.

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -44,11 +44,12 @@ export interface DomainStats {
 }
 
 export const getStats = async (): Promise<DomainStats> => {
-	const domainCount = await metaNamesSdk.domainRepository.count();
-	const ownerCount = await metaNamesSdk.domainRepository
-		.getOwners()
-		.then((owners) => owners.length);
-	const recentDomains = await getRecentDomains();
+	// ⚡ Bolt: Fetch stats concurrently to reduce total response time
+	const [domainCount, ownerCount, recentDomains] = await Promise.all([
+		metaNamesSdk.domainRepository.count(),
+		metaNamesSdk.domainRepository.getOwners().then((owners) => owners.length),
+		getRecentDomains()
+	]);
 
 	return {
 		domainCount,


### PR DESCRIPTION
💡 **What:**
Refactored the `getStats` function in `src/lib/server/index.ts` to fetch `domainCount`, `ownerCount`, and `recentDomains` concurrently using `Promise.all()`.

🎯 **Why:**
Previously, these statistics were fetched sequentially using `await` on each independent operation. This meant the total time was the sum of all individual requests. Since these queries do not depend on each other, they can be fetched concurrently.

📊 **Impact:**
Reduces the overall response time of the `getStats` function by executing the network/database requests in parallel. The new total execution time will be approximately equal to the duration of the longest single request, rather than the sum of all requests.

🔬 **Measurement:**
This improvement can be verified by observing a reduction in latency on endpoints that depend on `getStats` (e.g., `api/domains/stats`).

⚡ **Bolt Optimization**

---
*PR created automatically by Jules for task [14344971667530880236](https://jules.google.com/task/14344971667530880236) started by @yeboster*