### PR TITLE
🎨 Palette: Improve search input UX and accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.
+
+## 2024-10-24 - Dynamic Search Input Icons
+**Learning:** Having a permanent "cancel" or "clear" icon on a search input when it's empty creates a false affordance, as there is nothing to clear. Additionally, using `aria-label="cancel"` for clearing a search can be ambiguous to screen reader users.
+**Action:** Conditionally render the clear icon only when text is present (e.g., `{#if search.length > 0}`), and use a disabled "search" icon otherwise. Always use explicit action-oriented labels like `aria-label="Clear search"`.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -58,11 +58,19 @@
 					withTrailingIcon
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search.length > 0}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="Clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{:else}
+							<div class="search-icon">
+								<IconButton disabled aria-label="search">
+									<Icon icon="search" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />
@@ -88,7 +96,8 @@
 		min-width: 50%;
 	}
 
-	.close-icon {
+	.close-icon,
+	.search-icon {
 		align-self: center;
 		opacity: 0.7;
 	}


### PR DESCRIPTION
**💡 What:** 
Modified the profile search input to dynamically show a disabled search icon when empty, and a functional "clear" icon when there is text. Updated the `aria-label` on the clear button to be more descriptive ("Clear search" instead of "cancel").

**🎯 Why:** 
A permanent "cancel" icon creates a false affordance when the search box is empty (there is nothing to cancel/clear). Dynamically changing the icon gives users immediate visual feedback on the input state. Additionally, "cancel" was an ambiguous label for screen readers.

**📸 Before/After:** 
- Before: Always showed a clickable ❌ icon with `aria-label="cancel"`.
- After: Shows a disabled 🔍 icon when empty. Shows a clickable ❌ icon with `aria-label="Clear search"` when text is entered.

**♿ Accessibility:** 
- Prevents false focus/click targets for empty inputs.
- Provides a clear and descriptive `aria-label="Clear search"` for assistive technologies, replacing the ambiguous "cancel".

---
*PR created automatically by Jules for task [8475974177264859427](https://jules.google.com/task/8475974177264859427) started by @yeboster*