### PR TITLE
🎨 Palette: Add dynamic clear icon and fix reactivity in domains search

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -59,9 +61,15 @@
 				>
 					<svelte:fragment slot="trailingIcon">
 						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
+							{#if search === ''}
+								<IconButton aria-label="search" disabled>
+									<Icon icon="search" />
+								</IconButton>
+							{:else}
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							{/if}
 						</div>
 					</svelte:fragment>
 				</Textfield>


### PR DESCRIPTION
**💡 What:** 
Added a contextual trailing icon to the domains search bar on the profile page (`src/routes/profile/+page.svelte`). When the search input is empty, a disabled "search" magnifying glass icon is displayed. When a user types text, it dynamically swaps to a clickable "cancel/clear" icon that allows the user to quickly reset their search. Additionally, fixed a reactivity bug where manually clearing the input field (e.g. using backspace) did not properly reset the `domainsFiltered` list.

**🎯 Why:** 
- **Usability:** Users expect modern search bars to provide a quick "clear" button once they begin typing, rather than relying solely on backspace. 
- **Affordance:** Displaying a disabled "search" icon provides an immediate visual cue that the field is for searching, while swapping it avoids a confusing "cancel" button when there is nothing to cancel.
- **Bug Fix:** The missing `else` branch in the Svelte reactive statement caused the filtered list to remain statically filtered even after the user cleared their search query entirely.

**📸 Before/After:** 
_Before:_ The search bar permanently displayed a clickable "cancel" icon regardless of state, and clearing the input manually did not reset the domains list.
_After:_ 
1. Empty state: Shows a disabled "search" icon.
2. Typed state: Shows a clickable "clear" icon.
3. Clearing text correctly restores the full domains list.

**♿ Accessibility:** 
- The disabled state properly passes `disabled` to the `<IconButton>` so screen readers understand it is inactive.
- The `aria-label` dynamically updates to reflect the active functionality: `"search"` when empty (disabled) and `"clear search"` when active.

---
*PR created automatically by Jules for task [1694863054707766449](https://jules.google.com/task/1694863054707766449) started by @yeboster*