### PR TITLE
🎨 Palette: [UX improvement] Fix domain list filtering

### DIFF
--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 


### PR DESCRIPTION
💡 **What**: The UX enhancement added
Fixed an issue in the Profile page's domain search functionality where clearing the search input via the backspace or delete key failed to reset the filtered domains list to its original state.

🎯 **Why**: The user problem it solves
Previously, if a user searched for a domain and then decided to clear the search input, the filtered list would remain stuck, displaying only the previously matched results instead of the entire domain list. This was highly unintuitive, creating a frustrating experience where users had to refresh the page or perform another blank action to see all their domains again. Adding proper reset logic to the reactive search statement ensures the UI always accurately reflects the user's current search intent.

📸 **Before/After**: Screenshots if visual change
No visual layout changes; behavior change only.

♿ **Accessibility**: Any a11y improvements made
This ensures that users relying on keyboard navigation (e.g. using backspace to clear the input instead of clicking a clear button) are not penalized and experience the correct default state behavior.

---
*PR created automatically by Jules for task [11525502837704954154](https://jules.google.com/task/11525502837704954154) started by @yeboster*