### PR TITLE
⚡ Bolt: Optimize voter lookup

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,4 @@
 
 **Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
 **Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.
+## 2024-05-18 - [Optimization] Array vs Set Lookups\n**Learning:** Replaced O(N*M) `Array.includes` lookups in filters with O(N+M) `Set.has`.\n**Action:** Always prefer `Set` lookups over arrays inside loops or filters, particularly when the collections may grow.

--- a/src/routes/api/proposals/voters/add/+server.ts
+++ b/src/routes/api/proposals/voters/add/+server.ts
@@ -23,7 +23,9 @@ export async function GET() {
 			?.setValue()
 			.values.map((voter) => voter.addressValue().value.toString('hex')) ?? [];
 
-	const newVoters = owners.filter((owner) => !voters.includes(owner)).slice(0, 50);
+	// Use Set for O(1) lookups instead of O(N) Array.includes
+	const votersSet = new Set(voters);
+	const newVoters = owners.filter((owner) => !votersSet.has(owner)).slice(0, 50);
 	if (newVoters.length === 0) return json({ newVoters }, { status: 200 });
 
 	const votingContract = await metaNamesSdk.contractRepository.getContract({

--- a/src/routes/api/proposals/voters/remove/+server.ts
+++ b/src/routes/api/proposals/voters/remove/+server.ts
@@ -25,7 +25,9 @@ export async function GET() {
 			?.setValue()
 			.values.map((voter) => voter.addressValue().value.toString('hex')) ?? [];
 
-	const votersToRemove = voters.filter((voter) => !owners.includes(voter)).slice(0, 50);
+	// Use Set for O(1) lookups instead of O(N) Array.includes
+	const ownersSet = new Set(owners);
+	const votersToRemove = voters.filter((voter) => !ownersSet.has(voter)).slice(0, 50);
 	if (votersToRemove.length === 0) return json({ newVoters: votersToRemove }, { status: 200 });
 
 	const votingContract = await metaNamesSdk.contractRepository.getContract({


### PR DESCRIPTION
💡 **What**: Optimized array lookups in the proposal voter endpoints by converting target arrays into `Set`s before running filter loops.
🎯 **Why**: When `owners` and `voters` lists scale up to thousands of entries, `array.filter(item => !otherArray.includes(item))` degrades dramatically as it acts as an O(N * M) loop.
📊 **Impact**: Reduces time complexity for these operations from O(N * M) to O(N + M). This ensures that lookup time stays fast even if domain owner or voter lists grow extensively.
🔬 **Measurement**: Standard `pnpm test:unit --run` tests pass. The execution of the `GET` methods will visibly perform much faster when acting on large data sets.

---
*PR created automatically by Jules for task [7981816778547923068](https://jules.google.com/task/7981816778547923068) started by @yeboster*