### PR TITLE
🎨 Palette: [UX improvement] Fix search reset and clear button accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,4 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+## 2026-04-19 - Textfield conditional Trailing Icon\n**Learning:** When conditionally rendering a trailing icon inside an SMUI `Textfield` component, the `withTrailingIcon` property must also be dynamically bound to the same condition (e.g. `withTrailingIcon={search !== ''}`) rather than a static boolean. If left static, the input's CSS padding will reserve space for the icon even when the icon is not rendered, resulting in awkward whitespace.\n**Action:** Ensure both the `{#if}` block around the icon and the `withTrailingIcon` prop share the exact same boolean expression.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="Clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
**What:**
- Added an `else` block to reset `domainsFiltered` back to `domains` when the user clears the search input.
- Added a conditional `{#if search !== ''}` wrapper to the clear icon in the search `Textfield` so it only appears when there's text to clear, and dynamically toggled `withTrailingIcon={search !== ''}`.
- Updated the clear icon's `aria-label` from generic `"cancel"` to a more descriptive `"Clear search"`.

**Why:**
- Previously, if a user cleared their search query (e.g. using the backspace key), the domain list did not reset to the full list. It stayed filtered.
- The cancel icon was permanently visible even when the field was empty, adding unnecessary visual clutter.
- The generic `aria-label="cancel"` provided poor context to screen readers on what the button actually accomplished.

**Accessibility:**
- The clear button is now properly labeled with an action-oriented descriptive `aria-label` ("Clear search" instead of "cancel") for better screen-reader navigation.

---
*PR created automatically by Jules for task [16905574633339019284](https://jules.google.com/task/16905574633339019284) started by @yeboster*