### PR TITLE
🎨 Palette: Search filter reset and clear button UX improvement

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,8 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+
+## 2024-10-25 - Trailing Icons and Search Filtering Resets
+
+**Learning:** When using reactive variables for search filtering (`$: if (search !== '') ...`), failing to add an `else` block causes the UI to freeze in the filtered state when the user clears the input with backspace. Also, when an SMUI `Textfield` has a dynamic trailing icon, its `withTrailingIcon` attribute must be bound to the same condition; leaving it statically `true` leaves a gap in the UI when the icon unmounts.
+**Action:** Always include an `else` clause to restore the original list when the search is cleared, and dynamically bind `withTrailingIcon` to the presence of the search query. And always make sure the clear button has an accessible label like "Clear search".

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="Clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 **What**: Added an `else` clause to the search filter reactive statement to properly reset the domains list when the search is cleared. Also improved the search input's trailing "Clear" button by hiding it and resetting `withTrailingIcon` dynamically when the search is empty.
🎯 **Why**: Previously, clearing the search input (e.g. via backspace) wouldn't restore the full domains list, creating a confusing state where the table appeared permanently filtered. Additionally, statically rendering `withTrailingIcon` caused a layout gap when the clear icon was manually unmounted.
♿ **Accessibility**: Changed the clear button's `aria-label` from `"cancel"` to `"Clear search"` to provide a more descriptive experience for screen reader users.

---
*PR created automatically by Jules for task [17906107089875550673](https://jules.google.com/task/17906107089875550673) started by @yeboster*