### PR TITLE
🎨 Palette: Profile Search UX & Accessibility Improvements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+
+## 2024-10-24 - Dynamic Search Icons and Reactivity Reset
+**Learning:** Svelte reactive statements used for filtering data (`$: if (search !== '') { filtered = items }`) often miss the reset state if they omit the `else` clause. When a user deletes their search query via keyboard, the list won't reset. Additionally, trailing icons in components like SMUI Textfields must be dynamically bound (`withTrailingIcon={condition}`) to adjust layout correctly when the icon is conditionally hidden to avoid empty padded space.
+**Action:** Always include an `else` clause in search filtering reactive statements and ensure component properties (like padding flags) are dynamically synced with conditionally rendered child elements.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="Clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 **What**: Added reactivity reset to the profile search filter and conditionally rendered the trailing clear search icon based on input state. 

🎯 **Why**: When a user searched for a domain in their profile and subsequently cleared the input using the backspace/delete key, the search filter reactive block failed to reset the filtered domain list. Furthermore, the search bar displayed a persistent clear icon regardless of input state. This PR fixes the reactive statement and adds dynamic binding to properly reset states and conditional rendering.

📸 **Before/After**: Visually, the empty search input in the Profile page will no longer present a redundant 'X' (cancel) icon when no text is present.

♿ **Accessibility**: Changed the generic aria-label `"cancel"` to a descriptive `"Clear search"` to provide proper context to screen readers focusing on the icon button.

---
*PR created automatically by Jules for task [15647881262780954841](https://jules.google.com/task/15647881262780954841) started by @yeboster*