### PR TITLE
⚡ Bolt: [performance improvement] Convert array lookup to Set lookup in voter APIs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 
 **Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
 **Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.
+## 2026-04-24 - Array Loop Optimization
+**Learning:** Replacing an O(N * M) `.includes()` lookup inside a `.filter()` loop with a Set `.has()` lookup (O(1)) significantly improves algorithmic efficiency for large arrays, converting the total time complexity to O(N).
+**Action:** Use Sets instead of array `.includes()` when filtering or iterating over arrays based on membership in another array, specifically in server-side endpoints processing lists (like `voters/add` and `voters/remove`).

--- a/src/routes/api/proposals/voters/add/+server.ts
+++ b/src/routes/api/proposals/voters/add/+server.ts
@@ -23,7 +23,8 @@ export async function GET() {
 			?.setValue()
 			.values.map((voter) => voter.addressValue().value.toString('hex')) ?? [];
 
-	const newVoters = owners.filter((owner) => !voters.includes(owner)).slice(0, 50);
+	const votersSet = new Set(voters);
+	const newVoters = owners.filter((owner) => !votersSet.has(owner)).slice(0, 50);
 	if (newVoters.length === 0) return json({ newVoters }, { status: 200 });
 
 	const votingContract = await metaNamesSdk.contractRepository.getContract({

--- a/src/routes/api/proposals/voters/remove/+server.ts
+++ b/src/routes/api/proposals/voters/remove/+server.ts
@@ -25,7 +25,8 @@ export async function GET() {
 			?.setValue()
 			.values.map((voter) => voter.addressValue().value.toString('hex')) ?? [];
 
-	const votersToRemove = voters.filter((voter) => !owners.includes(voter)).slice(0, 50);
+	const ownersSet = new Set(owners);
+	const votersToRemove = voters.filter((voter) => !ownersSet.has(voter)).slice(0, 50);
 	if (votersToRemove.length === 0) return json({ newVoters: votersToRemove }, { status: 200 });
 
 	const votingContract = await metaNamesSdk.contractRepository.getContract({


### PR DESCRIPTION
What: Replaced the O(N * M) `.includes()` lookup with an O(1) Set `.has()` lookup in the `voters/add` and `voters/remove` API endpoints.
Why: The nested loops created a performance bottleneck when dealing with potentially large arrays of owners and voters.
Impact: Reduces the time complexity from O(N * M) to O(N + M), significantly improving endpoint efficiency as the size of the arrays grows.
Measurement: Compare response times of the add/remove voter endpoints locally using large mock datasets.

---
*PR created automatically by Jules for task [16744894840628140064](https://jules.google.com/task/16744894840628140064) started by @yeboster*