### PR TITLE
🎨 Palette: [UX improvement] Enhance search input behavior and feedback

### DIFF
--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="cancel">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 **What:** 
- Modified `src/routes/profile/+page.svelte` to conditionally show the `withTrailingIcon` property and its internal cross icon only `{#if search !== ''}`.
- Added an `else` branch to the reactive statement `$: if (search !== '')` to reset `domainsFiltered` back to `domains` when the search string is cleared.

🎯 **Why:** 
- The search functionality was failing to reset the list when users manually cleared the input with their keyboard (backspace/delete), leading to a permanently filtered list state.
- The trailing close/cancel icon was always rendered, even on an empty input. This is confusing for users as it implies there is text to clear when there isn't.

📸 **Before/After:**
- **Before:** Close icon present on empty input. Deleting text did not reset the table.
- **After:** Close icon only present when typing. Deleting text resets the table accurately.

♿ **Accessibility:**
- Reduces visual clutter by removing unnecessary interactive elements (the clear button) when they are not applicable.

---
*PR created automatically by Jules for task [12364435355787081378](https://jules.google.com/task/12364435355787081378) started by @yeboster*