### PR TITLE
🎨 Palette: [UX improvement] Add aria-label to Chip action icons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/src/components/Chip.svelte
+++ b/src/components/Chip.svelte
@@ -36,11 +36,11 @@
 		</div>
 	</Label>
 	{#if $icon === 'done'}
-		<Icon icon="done" align="right" />
+		<span role="img" aria-label="Copied"><Icon icon="done" align="right" /></span>
 	{:else if $icon === 'open-in-new'}
-		<Icon icon="open-in-new" align="right" />
+		<span role="img" aria-label="Open in new tab"><Icon icon="open-in-new" align="right" /></span>
 	{:else if $icon === 'content-copy'}
-		<Icon icon="content-copy" align="right" />
+		<span role="img" aria-label="Copy"><Icon icon="content-copy" align="right" /></span>
 	{/if}
 </Button>
 


### PR DESCRIPTION
💡 **What:** Added `aria-label` tags with a `role="img"` wrapper to the dynamic action icons inside the `Chip` component.
🎯 **Why:** To improve accessibility by explicitly indicating to users (and screen readers) what the icon-only buttons do (e.g. "Copy", "Open in new tab", "Copied") which makes the UI significantly more accessible.
📸 **Before/After:** The visual layout is unaffected, but the screen reader can now properly read out the purpose of the action icon.
♿ **Accessibility:** Screen readers will now be able to interpret the action icons, increasing the semantic value of the component.

---
*PR created automatically by Jules for task [10379029941527895077](https://jules.google.com/task/10379029941527895077) started by @yeboster*