### PR TITLE
🎨 Palette: [UX improvement] Enhance profile search input behavior

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,8 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.
+
+## 2024-10-24 - Trailing Icons and Reactive Reset
+**Learning:** When conditionally rendering a trailing icon inside an SMUI `Textfield` component, ensure the `withTrailingIcon` property is dynamically bound to the same rendering condition (e.g., `withTrailingIcon={search !== ''}`) rather than left as a static boolean flag, otherwise the input's layout and padding will not update correctly when the icon is unmounted. Also, when using Svelte reactive statements to filter lists based on search input (e.g., `$: if (search !== '') { filtered = all.filter(...) }`), always include an `else` clause (e.g., `else { filtered = all }`) to ensure the list correctly resets when the user clears the input via keyboard (backspace/delete).
+**Action:** Always check the `withTrailingIcon` prop dynamically and double check reactive statements have complete conditional resets.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
**💡 What:** 
1. Conditionally renders the search input's clear (`cancel`) button only when there is actually text in the search input.
2. Fixes a logic bug where clearing the search field with the backspace/delete key failed to reset the filtered domains list.
3. Dynamically binds the `withTrailingIcon` property to ensure SMUI textfield padding is correct when the icon mounts/unmounts.
4. Updates the clear button's `aria-label` to be more descriptive.

**🎯 Why:**
Showing a "cancel" button when a search input is completely empty is confusing UX. Hiding it until needed provides a cleaner interface. Additionally, the reactive statement filtering the domains lacked an `else` block, meaning if a user manually cleared the input using their keyboard, the domain list would remain incorrectly filtered.

**📸 Before/After:**
*(Visually verified via static mock: empty input shows no icon, filled input shows the clear icon).*

**♿ Accessibility:**
Updated the `<IconButton>` `aria-label` from generic `"cancel"` to `"clear search"` to provide precise context for screen readers.

---
*PR created automatically by Jules for task [3951105374620590060](https://jules.google.com/task/3951105374620590060) started by @yeboster*