### PR TITLE
🎨 Palette: Improve profile domain search UX and accessibility

### DIFF
--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -52,17 +54,19 @@
 				<h4 class="domains">Domains</h4>
 				<Textfield
 					class="my-1 search-bar"
-					label="Search"
+					label="Search domains"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="Clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 **What:** Improved the UX and accessibility of the domain search bar on the Profile page.
🎯 **Why:** Previously, if a user cleared the search input using the backspace key, the domain list would not reset back to the full list due to a missing `else` branch in the reactive statement. Also, the search bar's clear button was always visible and lacked descriptive accessibility labels.
📸 **Before/After:** The clear icon is now only visible when there is text to clear, reducing visual noise.
♿ **Accessibility:** Updated the input label to 'Search domains' and the clear button `aria-label` to 'Clear search' instead of 'cancel'.

---
*PR created automatically by Jules for task [8853705019027692369](https://jules.google.com/task/8853705019027692369) started by @yeboster*