### PR TITLE
⚡ Bolt: [performance improvement] Optimize array lookups in voters endpoints

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,8 @@
 
 **Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
 **Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.
+
+## 2024-11-20 - O(N*M) Array Lookups in Filters
+
+**Learning:** Symmetrical O(N*M) array lookups (like `.filter(item => !array.includes(item))`) in server-side endpoints processing lists (e.g., adding/removing voters) cause unnecessary computational overhead on large datasets.
+**Action:** Convert the lookup array into a `Set` (O(1) complexity) before the loop to optimize the filter operation to O(N).

--- a/src/routes/api/proposals/voters/add/+server.ts
+++ b/src/routes/api/proposals/voters/add/+server.ts
@@ -23,7 +23,9 @@ export async function GET() {
 			?.setValue()
 			.values.map((voter) => voter.addressValue().value.toString('hex')) ?? [];
 
-	const newVoters = owners.filter((owner) => !voters.includes(owner)).slice(0, 50);
+	// Use a Set for O(1) lookups instead of O(N) array includes
+	const votersSet = new Set(voters);
+	const newVoters = owners.filter((owner) => !votersSet.has(owner)).slice(0, 50);
 	if (newVoters.length === 0) return json({ newVoters }, { status: 200 });
 
 	const votingContract = await metaNamesSdk.contractRepository.getContract({

--- a/src/routes/api/proposals/voters/remove/+server.ts
+++ b/src/routes/api/proposals/voters/remove/+server.ts
@@ -25,7 +25,9 @@ export async function GET() {
 			?.setValue()
 			.values.map((voter) => voter.addressValue().value.toString('hex')) ?? [];
 
-	const votersToRemove = voters.filter((voter) => !owners.includes(voter)).slice(0, 50);
+	// Use a Set for O(1) lookups instead of O(N) array includes
+	const ownersSet = new Set(owners);
+	const votersToRemove = voters.filter((voter) => !ownersSet.has(voter)).slice(0, 50);
 	if (votersToRemove.length === 0) return json({ newVoters: votersToRemove }, { status: 200 });
 
 	const votingContract = await metaNamesSdk.contractRepository.getContract({


### PR DESCRIPTION
💡 What: Converted lookup arrays (`voters` and `owners`) into `Set`s before running `.filter()` on them in the voters API endpoints.
🎯 Why: The original implementation used `.includes()` inside `.filter()`, resulting in `O(N * M)` time complexity which degrades quickly for larger arrays of owners and voters.
📊 Impact: Improves algorithm complexity from `O(N * M)` to `O(N + M)`. Lookups inside the filter are now `O(1)` instead of `O(N)`.
🔬 Measurement: Verify changes in `src/routes/api/proposals/voters/add/+server.ts` and `src/routes/api/proposals/voters/remove/+server.ts`. Run `pnpm test:unit` to ensure no regressions.

---
*PR created automatically by Jules for task [13226858295956305365](https://jules.google.com/task/13226858295956305365) started by @yeboster*