### PR TITLE
⚡ Bolt: [performance improvement] Optimize array lookup in proposals API

### DIFF
--- a/src/routes/api/proposals/voters/add/+server.ts
+++ b/src/routes/api/proposals/voters/add/+server.ts
@@ -22,8 +22,9 @@ export async function GET() {
 			.get('voters')
 			?.setValue()
 			.values.map((voter) => voter.addressValue().value.toString('hex')) ?? [];
+	const votersSet = new Set(voters);
 
-	const newVoters = owners.filter((owner) => !voters.includes(owner)).slice(0, 50);
+	const newVoters = owners.filter((owner) => !votersSet.has(owner)).slice(0, 50);
 	if (newVoters.length === 0) return json({ newVoters }, { status: 200 });
 
 	const votingContract = await metaNamesSdk.contractRepository.getContract({

--- a/src/routes/api/proposals/voters/remove/+server.ts
+++ b/src/routes/api/proposals/voters/remove/+server.ts
@@ -24,8 +24,9 @@ export async function GET() {
 			.get('voters')
 			?.setValue()
 			.values.map((voter) => voter.addressValue().value.toString('hex')) ?? [];
+	const ownersSet = new Set(owners);
 
-	const votersToRemove = voters.filter((voter) => !owners.includes(voter)).slice(0, 50);
+	const votersToRemove = voters.filter((voter) => !ownersSet.has(voter)).slice(0, 50);
 	if (votersToRemove.length === 0) return json({ newVoters: votersToRemove }, { status: 200 });
 
 	const votingContract = await metaNamesSdk.contractRepository.getContract({


### PR DESCRIPTION
💡 **What**: Converted array `includes()` lookups to `Set.has()` lookups in the `add` and `remove` API endpoints under `src/routes/api/proposals/voters/`.
🎯 **Why**: The endpoints were filtering lists by iterating over an array and performing an `Array.includes()` check against another array on every iteration. This results in $O(N \times M)$ complexity.
📊 **Impact**: Reduces lookup time from $O(N)$ to $O(1)$, improving the overall complexity to $O(N + M)$. While arrays are currently limited to 50 items (making it a smaller win), this prevents potential performance degradation if limits are ever increased.
🔬 **Measurement**: Verified by reviewing the code complexity. Standard unit tests pass indicating no functional regression.

---
*PR created automatically by Jules for task [3802800581499667196](https://jules.google.com/task/3802800581499667196) started by @yeboster*