### PR TITLE
🎨 Palette: Improve profile domain search UX and accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,8 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+
+## 2024-11-20 - Dynamic Icons in Textfields and Search Resets
+
+**Learning:** When adding a conditional trailing icon (like a clear button) inside an SMUI Textfield, leaving `withTrailingIcon` as a static boolean causes incorrect layout and padding when the icon is unmounted. Furthermore, Svelte reactive statements for search filtering (e.g., `$: if (search !== '') { filtered = all.filter(...) }`) require an explicit `else { filtered = all }` to correctly reset the list when users clear the input using backspace or delete.
+**Action:** Dynamically bind `withTrailingIcon` to the same condition used to render the icon (e.g., `withTrailingIcon={search !== ''}`), and always include an `else` block to reset filtered lists to their default state when search strings become empty.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -37,9 +39,7 @@
 		const trimmedDomain = domain.trim().toLowerCase();
 		const trimmedSearch = search.trim().toLowerCase();
 
-		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
-			return true;
-		else false;
+		return trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch);
 	}
 </script>
 
@@ -55,14 +55,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="Clear search input">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 **What:** Added search reset functionality, dynamic input padding for conditionally rendered trailing icons, and an improved `aria-label` to the clear button on the profile page domain search.
🎯 **Why:** Previously, clearing the search input using the backspace key did not reset the filtered domains list. Additionally, the clear icon was present by default and had a generic 'cancel' `aria-label`. Dynamically rendering the icon when text is present provides clearer UX, and updating the aria label provides better accessibility. Svelte's reactive statements also require explicit `else` blocks to reset arrays appropriately when search params are empty.
📸 **Before/After:** The 'X' clear button only appears when the user types in the search field. The field padding adjusts accordingly. When cleared, the domain list resets to its default state.
♿ **Accessibility:** Changed the `aria-label` of the clear search icon from 'cancel' to 'Clear search input' to clearly articulate the button's action to screen readers.

---
*PR created automatically by Jules for task [3951143128640744063](https://jules.google.com/task/3951143128640744063) started by @yeboster*