### PR TITLE
🎨 Palette: Improve profile domain search UX and accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,8 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+
+## 2024-10-24 - Trailing Icons and Reactive List Resetting
+
+**Learning:** When conditionally rendering an `Icon` inside an SMUI `Textfield` slot (e.g. `trailingIcon`), the `withTrailingIcon` attribute must be bound to the exact same condition. Leaving it as a static boolean while unmounting the inner content breaks the layout padding. Additionally, reactive list filters (e.g., `$: if (search !== '') filtered = all.filter(...)`) fail to reset the list when users clear the input with backspace/delete.
+**Action:** Bind SMUI's `withTrailingIcon={condition}` and only render the icon slot content `{#if condition}`. For reactive filters, always include an `else { filtered = all }` block to handle keyboard-based input clearing correctly.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="Clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
### 💡 What
Improved the domain search input's responsiveness, layout behavior, and accessibility on the profile page.

### 🎯 Why
When a user cleared the search text using the backspace or delete key, the reactive Svelte list did not reset, leaving the user with a stale view. Additionally, unmounting the trailing clear icon while leaving `withTrailingIcon` dynamically true corrupted the Material UI input layout. Finally, the aria-label was too generic ("cancel"). 

### ♿ Accessibility
Updated the trailing button `aria-label` from "cancel" to a highly descriptive "Clear search" to better assist screen-reader users in understanding the button's purpose in the context of the input field.

---
*PR created automatically by Jules for task [6864935793803794678](https://jules.google.com/task/6864935793803794678) started by @yeboster*