### PR TITLE
🎨 Palette: [UX improvement] Fix Dialog Accessibility ID Mismatch and Uniqueness in Record.svelte

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,6 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+## 2024-10-25 - Fixing Dialog ID Mismatch
+**Learning:** Hardcoded IDs in SMUI `Dialog` components cause `aria-labelledby` and `aria-describedby` to reference invalid or duplicate IDs when multiple components are rendered in loops. This creates severe accessibility violations.
+**Action:** Use an `onMount` hook to dynamically generate and bind unique IDs for dialog titles and contents, ensuring proper ARIA reference resolution and uniqueness across instances.

--- a/src/components/Record.svelte
+++ b/src/components/Record.svelte
@@ -5,6 +5,7 @@
 	import CharacterCounter from '@smui/textfield/character-counter';
 	import Textfield from '@smui/textfield';
 	import Icon from 'src/components/Icon.svelte';
+	import { onMount } from 'svelte';
 
 	import type { RecordRepository } from '@metanames/sdk';
 	import { alertMessage, refresh, walletConnected } from '$lib/stores/main';
@@ -18,6 +19,11 @@
 
 	let recordValue = String(value);
 	let dialogOpen = false;
+	let dialogId = '';
+
+	onMount(() => {
+		dialogId = Math.random().toString(36).substring(2, 9);
+	});
 
 	$: label = klass.toString();
 	$: recordClass = getRecordClassFrom(klass);
@@ -55,11 +61,11 @@
 <div class="record-container {editMode ? 'edit' : ''}">
 	<Dialog
 		bind:open={dialogOpen}
-		aria-labelledby="confirmation-title"
-		aria-describedby="confirmation-content"
+		aria-labelledby="confirmation-title-{dialogId}"
+		aria-describedby="confirmation-content-{dialogId}"
 	>
-		<Title id="simple-title">Confirm action</Title>
-		<Content id="simple-content">Do you really want to remove the record?</Content>
+		<Title id="confirmation-title-{dialogId}">Confirm action</Title>
+		<Content id="confirmation-content-{dialogId}">Do you really want to remove the record?</Content>
 		<Actions>
 			<Button>
 				<Label>No</Label>


### PR DESCRIPTION
### 💡 What
Updated `Record.svelte` to dynamically generate a unique ID (`dialogId`) via `onMount`, fixing the mismatched and non-unique IDs previously assigned to the SMUI `Dialog`'s `aria-labelledby` and `aria-describedby` properties.

### 🎯 Why
SMUI `Dialog` components depend on IDs to associate title and content text with the modal correctly for screen readers. The old implementation referenced non-existent or hardcoded IDs (`confirmation-title`/`confirmation-content` vs `simple-title`/`simple-content`), breaking screen-reader announcements. Additionally, multiple `Record` components would result in duplicate IDs across the DOM. Using an `onMount` hook safely generates a unique ID on the client side without triggering SSR hydration warnings.

### ♿ Accessibility
* Fixed broken ARIA references (`aria-labelledby`, `aria-describedby`) for the delete confirmation dialog.
* Ensured DOM element IDs within the dialog are strictly unique across multiple loop iterations, complying with WCAG uniqueness rules.

---
*PR created automatically by Jules for task [6622620427853624608](https://jules.google.com/task/6622620427853624608) started by @yeboster*