### PR TITLE
🎨 Palette: [UX improvement] Profile Domain Search UX & Accessibility enhancements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,8 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+
+## 2026-05-03 - Svelte Reactive Array Filtering & SMUI Conditional Layout
+
+**Learning:** When using Svelte reactive statements to filter lists based on search input (e.g., `$: if (search !== '') { filtered = all.filter(...) }`), the list does not automatically reset when the user clears the input via keyboard (backspace/delete) unless an explicit `else` clause (e.g., `else { filtered = all }`) is provided. Furthermore, conditionally rendering a trailing icon inside an SMUI `Textfield` component requires dynamically binding the `withTrailingIcon` property to the same rendering condition (e.g., `withTrailingIcon={search !== ''}`); otherwise, the input's layout and padding will not update correctly when the icon is unmounted.
+**Action:** Always include an `else` clause in reactive search filter statements to handle the empty state, and ensure SMUI layout properties like `withTrailingIcon` match the conditional rendering state of their respective slots.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="Clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
### 💡 What
- Added an `else` clause to the Svelte reactive search filter to correctly reset the `domainsFiltered` list when the search query is emptied.
- Conditionally render the "clear search" trailing icon to only appear when the search string is not empty.
- Bound the `withTrailingIcon` property to the same condition so the underlying Material UI layout adapts accordingly.
- Improved the clear button's screen reader announcement by changing the `aria-label` from "cancel" to "Clear search".

### 🎯 Why
When users deleted their search text via backspace/delete keys, the Svelte reactive list was not repopulating with the original domains, leaving the UI stuck. Additionally, an always-visible empty trailing icon slot takes up padding and looks unpolished. Using a more descriptive `aria-label` improves clarity for users relying on assistive technology.

### ♿ Accessibility
Improved the generic "cancel" `aria-label` on the search clearing `IconButton` to "Clear search" for better screen reader contextualization.

---
*PR created automatically by Jules for task [5928210138832785867](https://jules.google.com/task/5928210138832785867) started by @yeboster*