### PR TITLE
⚡ Bolt: Optimize voter array lookups to Sets

### DIFF
--- a/src/routes/api/proposals/voters/add/+server.ts
+++ b/src/routes/api/proposals/voters/add/+server.ts
@@ -22,8 +22,9 @@ export async function GET() {
 			.get('voters')
 			?.setValue()
 			.values.map((voter) => voter.addressValue().value.toString('hex')) ?? [];
+	const votersSet = new Set(voters);
 
-	const newVoters = owners.filter((owner) => !voters.includes(owner)).slice(0, 50);
+	const newVoters = owners.filter((owner) => !votersSet.has(owner)).slice(0, 50);
 	if (newVoters.length === 0) return json({ newVoters }, { status: 200 });
 
 	const votingContract = await metaNamesSdk.contractRepository.getContract({

--- a/src/routes/api/proposals/voters/remove/+server.ts
+++ b/src/routes/api/proposals/voters/remove/+server.ts
@@ -24,8 +24,9 @@ export async function GET() {
 			.get('voters')
 			?.setValue()
 			.values.map((voter) => voter.addressValue().value.toString('hex')) ?? [];
+	const ownersSet = new Set(owners);
 
-	const votersToRemove = voters.filter((voter) => !owners.includes(voter)).slice(0, 50);
+	const votersToRemove = voters.filter((voter) => !ownersSet.has(voter)).slice(0, 50);
 	if (votersToRemove.length === 0) return json({ newVoters: votersToRemove }, { status: 200 });
 
 	const votingContract = await metaNamesSdk.contractRepository.getContract({


### PR DESCRIPTION
💡 **What**: Converted the `voters` and `owners` arrays into a `Set` before performing filtering operations in `src/routes/api/proposals/voters/add/+server.ts` and `src/routes/api/proposals/voters/remove/+server.ts`.
🎯 **Why**: Previously, these endpoints were looping through an array and performing an `Array.prototype.includes()` check inside the `.filter()` method, which is an $O(N \times M)$ operation. Using a `Set` replaces this with an $O(1)$ lookup per item.
📊 **Impact**: Reduces time complexity for voter filtering from $O(N \times M)$ down to $O(N + M)$, significantly speeding up execution times for these endpoints when processing large numbers of domains/voters.
🔬 **Measurement**: Verified the logic functionally remains identical. The unit tests pass, and this follows standard algorithmic optimization practices.

---
*PR created automatically by Jules for task [15664976945271017298](https://jules.google.com/task/15664976945271017298) started by @yeboster*