### PR TITLE
🎨 Palette: [UX improvement] Fix WalletConnectButton menu anchoring and accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,9 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.
+
+## 2026-05-04 - Native MDC Menu Anchoring
+
+**Learning:** SMUI (Svelte Material UI) and Material Design Components support native menu anchoring. Using custom CSS position overrides (like `left: unset !important`) breaks accessibility patterns and proper floating behavior. The correct approach is to wrap the trigger and the `<Menu>` in a container with the `mdc-menu-surface--anchor` class, bind the anchor element to the menu, and use MDC's built-in `anchorCorner` properties (e.g. `BOTTOM_END`) to position it relative to the trigger.
+**Action:** Use native `mdc-menu-surface--anchor` and `anchorCorner` properties for dropdown positioning instead of manual CSS hacks. Add `aria-haspopup="listbox"` and `aria-expanded` to trigger buttons to ensure full keyboard and screen reader accessibility.

--- a/src/routes/WalletConnectButton.svelte
+++ b/src/routes/WalletConnectButton.svelte
@@ -97,51 +97,57 @@
 	export let connectButtonVariant: 'raised' | 'unelevated' | 'outlined' = 'raised';
 </script>
 
-<Button variant={connectButtonVariant} on:click={toggleMenu}>
-	<slot name="buttonLabel">Connect</slot>
-</Button>
-<Menu
-	bind:this={menu}
-	on:SMUIMenuSurface:closed={() => (toggleOpen = false)}
-	class="menu-floating-right"
-	anchor={true}
-	bind:anchorElement={anchor}
-	anchorCorner="BOTTOM_LEFT"
->
-	<List>
-		{#if $walletConnected}
-			<slot name="connectedMenuIems" />
-			<Item on:SMUI:action={async () => disconnectWallet().then(toggleMenu)}>
-				<Text>Disconnect</Text>
-			</Item>
-		{:else}
-			<Item on:SMUI:action={connectWithMetaMaskWallet}>
-				<Text>
-					<div class="item">
-						<img class="logo" src={metamaskLogo} alt="metamask wallet logo" />
-						<span>Meta Mask Wallet</span>
-					</div>
-				</Text>
-			</Item>
-			<Item on:SMUI:action={connectWithPartisiaWallet}>
-				<Text>
-					<div class="item">
-						<img class="logo" src={partisiaWalletLogo} alt="partisia wallet logo" />
-						<span>Partisia Wallet</span>
-					</div>
-				</Text>
-			</Item>
-			<Item on:SMUI:action={connectWithLedgerWallet}>
-				<Text>
-					<div class="item">
-						<img class="logo" src={ledgerWalletLogo} alt="partisia wallet logo" />
-						<span>Ledger</span>
-					</div>
-				</Text>
-			</Item>
-		{/if}
-	</List>
-</Menu>
+<div class="mdc-menu-surface--anchor" bind:this={anchor}>
+	<Button
+		variant={connectButtonVariant}
+		on:click={toggleMenu}
+		aria-haspopup="listbox"
+		aria-expanded={toggleOpen}
+	>
+		<slot name="buttonLabel">Connect</slot>
+	</Button>
+	<Menu
+		bind:this={menu}
+		on:SMUIMenuSurface:closed={() => (toggleOpen = false)}
+		anchor={true}
+		bind:anchorElement={anchor}
+		anchorCorner="BOTTOM_END"
+	>
+		<List>
+			{#if $walletConnected}
+				<slot name="connectedMenuIems" />
+				<Item on:SMUI:action={async () => disconnectWallet().then(toggleMenu)}>
+					<Text>Disconnect</Text>
+				</Item>
+			{:else}
+				<Item on:SMUI:action={connectWithMetaMaskWallet}>
+					<Text>
+						<div class="item">
+							<img class="logo" src={metamaskLogo} alt="metamask wallet logo" />
+							<span>Meta Mask Wallet</span>
+						</div>
+					</Text>
+				</Item>
+				<Item on:SMUI:action={connectWithPartisiaWallet}>
+					<Text>
+						<div class="item">
+							<img class="logo" src={partisiaWalletLogo} alt="partisia wallet logo" />
+							<span>Partisia Wallet</span>
+						</div>
+					</Text>
+				</Item>
+				<Item on:SMUI:action={connectWithLedgerWallet}>
+					<Text>
+						<div class="item">
+							<img class="logo" src={ledgerWalletLogo} alt="ledger wallet logo" />
+							<span>Ledger</span>
+						</div>
+					</Text>
+				</Item>
+			{/if}
+		</List>
+	</Menu>
+</div>
 
 <style lang="scss">
 	.logo {

--- a/src/styles/wallet-connect.scss
+++ b/src/styles/wallet-connect.scss
@@ -1,4 +1,0 @@
-/* Hack to make the top nav bar menu appear on the right */
-.menu-floating-right {
-	left: unset !important;
-}


### PR DESCRIPTION
### 💡 What
- Wrapped the Wallet Connect `<Button>` and `<Menu>` in an `mdc-menu-surface--anchor` wrapper.
- Switched the Menu anchor behavior to use MDC's built-in `BOTTOM_END` corner alignment.
- Added `aria-haspopup` and `aria-expanded` properties to the dropdown trigger button.
- Fixed an incorrect `alt` string on the Ledger wallet icon.
- Removed the manual `.menu-floating-right { left: unset !important }` CSS hack.

### 🎯 Why
Native MDC alignment properties resolve issues with unexpected clipping and overlapping when floating menus are styled using manual CSS `left: unset !important` overrides. The previous trigger button was also lacking accessibility markers, making it difficult for screen reader users to identify its behavior.

### ♿ Accessibility
- Added `aria-haspopup="listbox"` to clearly indicate to screen readers that the Connect button opens a dropdown options list.
- Added dynamic `aria-expanded={toggleOpen}` to broadcast the menu's current expanded or collapsed state.
- Fixed Ledger icon alt text (was incorrectly labeled as "partisia wallet logo").

---
*PR created automatically by Jules for task [11307232044816351402](https://jules.google.com/task/11307232044816351402) started by @yeboster*