### PR TITLE
🎨 Palette: [UX improvement] add aria menu roles and states to connect wallet button

### DIFF
--- a/src/routes/WalletConnectButton.svelte
+++ b/src/routes/WalletConnectButton.svelte
@@ -97,7 +97,12 @@
 	export let connectButtonVariant: 'raised' | 'unelevated' | 'outlined' = 'raised';
 </script>
 
-<Button variant={connectButtonVariant} on:click={toggleMenu}>
+<Button
+	variant={connectButtonVariant}
+	on:click={toggleMenu}
+	aria-haspopup="menu"
+	aria-expanded={toggleOpen}
+>
 	<slot name="buttonLabel">Connect</slot>
 </Button>
 <Menu


### PR DESCRIPTION
💡 What: Added `aria-haspopup` and `aria-expanded` attributes to the Connect `<Button>` in `WalletConnectButton.svelte`.
🎯 Why: Screen readers and keyboard navigation didn't have adequate indication that the button controlled an expand/collapse state for a pop-up menu context. 
♿ Accessibility: Ensures that users utilizing assistive technology can identify that the button triggers a menu list and whether that list is currently visible or hidden.

---
*PR created automatically by Jules for task [12484364112183480880](https://jules.google.com/task/12484364112183480880) started by @yeboster*