### PR TITLE
🎨 Palette: [UX improvement] Fix search clearing logic and button visibility on Profile page

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,8 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+
+## 2024-05-06 - Fixing Search Bar State and Clear Button
+
+**Learning:** When using reactive statements like `$: if (search !== '')` to filter lists in Svelte, it is essential to include an `else` block to reset the state when the input is cleared. In SMUI Textfields, dynamically rendering the trailing icon requires both wrapping the slot content in an `{#if}` block and binding `withTrailingIcon={condition}` on the Textfield itself to maintain correct internal padding and layout.
+**Action:** Always test search and clear interactions completely (including keyboard deletion). Ensure `withTrailingIcon` dynamically matches the trailing icon rendering condition. Ensure aria-labels are descriptive of the action rather than the icon name itself (e.g., "clear search" vs "cancel").

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 **What:** 
- Corrected the domain list reactive filtering so it properly resets to show all domains when the search input is cleared.
- Conditionally hide the trailing "clear search" icon button when the input is empty to remove unnecessary visual clutter.
- Fixed a minor JavaScript semantic bug (`else false;` -> `else return false;`) in `isFuzzyMatch`.

🎯 **Why:** 
Previously, clearing the domain search input via backspace would not reset the displayed list of domains, leaving users stuck with filtered results. Additionally, the clear (X) button was always permanently visible even when the field was empty, which goes against standard search UI patterns. 

♿ **Accessibility:**
Updated the `aria-label` on the clear button from `"cancel"` to `"clear search"` to provide a more accurate and descriptive experience for screen reader users.

---
*PR created automatically by Jules for task [12628707360344799512](https://jules.google.com/task/12628707360344799512) started by @yeboster*