### PR TITLE
🎨 Palette: Improve profile page domain search UX and accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,4 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="Clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
**💡 What**
Improved the search input UX and accessibility on the profile page. Specifically:
- The trailing clear (cancel) icon only appears when there is text in the search input.
- The `withTrailingIcon` property dynamically toggles to prevent incorrect UI padding when empty.
- When the user clears the input via keyboard (backspace/delete), the domain list properly resets to show all domains.

**🎯 Why**
Previously, the clear button was permanently visible even when the field was empty, which is visually confusing. Additionally, clearing the text manually with the keyboard failed to reset the domain list back to its original state, trapping the user in a filtered view. The ARIA label was also updated from "cancel" to "Clear search" to be more descriptive for screen readers.

**♿ Accessibility**
- Updated the clear button's `aria-label` from `"cancel"` to `"Clear search"`, providing better context for assistive technologies.

**📸 Before/After**
*Visual verification complete via Playwright.*

---
*PR created automatically by Jules for task [5314546949124849693](https://jules.google.com/task/5314546949124849693) started by @yeboster*