### PR TITLE
🎨 Palette: [UX] Hide clear search button when input is empty

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,6 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+## 2026-05-09 - Conditionally Rendering Trailing Icons in SMUI Textfields
+**Learning:** When conditionally rendering a trailing icon inside an SMUI `Textfield` component, ensure the `withTrailingIcon` property is dynamically bound to the same rendering condition (e.g., `withTrailingIcon={search !== ''}`) rather than left as a static boolean flag, otherwise the input's layout and padding will not update correctly when the icon is unmounted.
+**Action:** Always bind the `withTrailingIcon` and `withLeadingIcon` flags in SMUI textfields to their corresponding DOM node's rendering state.

--- a/.svelte-kit/tsconfig.json
+++ b/.svelte-kit/tsconfig.json
@@ -9,6 +9,9 @@
 			],
 			"$lib/*": [
 				"../src/lib/*"
+			],
+			"$app/types": [
+				"./types/index.d.ts"
 			]
 		},
 		"rootDirs": [
@@ -25,7 +28,10 @@
 		"moduleResolution": "bundler",
 		"module": "esnext",
 		"noEmit": true,
-		"target": "esnext"
+		"target": "esnext",
+		"types": [
+			"node"
+		]
 	},
 	"include": [
 		"ambient.d.ts",
@@ -36,6 +42,9 @@
 		"../src/**/*.js",
 		"../src/**/*.ts",
 		"../src/**/*.svelte",
+		"../test/**/*.js",
+		"../test/**/*.ts",
+		"../test/**/*.svelte",
 		"../tests/**/*.js",
 		"../tests/**/*.ts",
 		"../tests/**/*.svelte"

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -55,14 +55,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="Clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 **What**: Added conditional rendering for the clear search icon button in `src/routes/profile/+page.svelte` so it only appears when the search input is populated. Additionally, changed its aria-label from `"cancel"` to `"Clear search"`.
🎯 **Why**: When the search input is empty, a "clear search" button is redundant and potentially confusing since there is nothing to cancel. Removing it cleans up the UI. The updated aria-label is much more descriptive for screen reader users compared to a generic "cancel".
📸 **Before/After**: See attached visual verification.
♿ **Accessibility**: Improved `aria-label` description.

---
*PR created automatically by Jules for task [15233483596057878386](https://jules.google.com/task/15233483596057878386) started by @yeboster*