### PR TITLE
🎨 Palette: [UX improvement] Improve profile search behavior and accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+## 2024-05-10 - Clear Input Affordances and Svelte Reactivity
+
+**Learning:** When using conditional statements to filter arrays in Svelte based on an input's string value, it is critical to implement the `else` logic so the array correctly resets to its initial state when the string becomes empty. Furthermore, ensuring that interactive clear buttons are hidden when there is no text visually declutters the component and provides a more intuitive UX, while a descriptive `aria-label` like "Clear search" improves screen-reader accessibility over generic labels like "cancel".
+**Action:** Always include an `else` clause when binding reactive list filtering to input value length, hide clear inputs conditionally with `{#if value !== ''}`, and rigorously audit `aria-label`s on icon-only buttons for action-specific descriptions.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="Clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
🎨 Palette: [UX improvement] Improve profile search behavior and accessibility

**What:** 
- Added an `else` branch in the reactive statement for `search` in the profile page so that the domains list fully resets to the base array when the input is emptied.
- Conditionally hid the "Clear search" trailing icon inside the search input based on whether the `search` string has any content.

**Why:**
- When users cleared the input field (e.g. via keyboard backspace), the filtered domains remained stuck, which is an unexpected and broken filtering experience.
- The clear icon remained visible even when the input was empty, making it an unnecessary and confusing affordance on screen.

**Accessibility:**
- Changed the `aria-label` of the clear `IconButton` from the generic `"cancel"` to `"Clear search"`, providing explicit context to screen-reader users on exactly what action the icon performs.

---
*PR created automatically by Jules for task [9688069980080165810](https://jules.google.com/task/9688069980080165810) started by @yeboster*