### PR TITLE
🎨 Palette: [UX improvement] Conditionally render search clear button and improve a11y

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,8 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+
+## 2024-10-24 - Search Input UX/A11y
+
+**Learning:** Search inputs often leave clear buttons focusable and visible to screen readers even when the input is empty. Also, `cancel` as an aria-label isn't clear enough about what action the user is taking.
+**Action:** Always conditionally render clear buttons (e.g., `{#if search !== ''}`) so they only exist when usable, and use a descriptive aria-label like `"clear search"` instead of generic terms like `"cancel"`.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -55,14 +55,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
**What**:
Conditionally render the "clear search" icon inside the profile page domain search input so it does not exist in the DOM when the input is empty.

**Why**:
The empty search input rendered a clear button (the trailing icon) that was functionally useless but still focusable by keyboard navigation.

**Accessibility**:
Added `aria-label="clear search"` (replacing the confusing `aria-label="cancel"`) to the clear button to provide better context for screen readers.

**Before/After**:
Before, the textfield reserved space and focusable elements for a trailing icon even when `search === ''`. Now it is only rendered when there is text to clear.

---
*PR created automatically by Jules for task [16999615857382787506](https://jules.google.com/task/16999615857382787506) started by @yeboster*