### PR TITLE
🎨 Palette: [UX improvement] Enhance profile domains search interaction and accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,8 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+
+## 2026-05-12 - Conditional Render for Decorative Input Icons
+
+**Learning:** Decorative or action icons within text inputs (like 'clear search' icons) must be conditionally rendered. If an empty state leaves an invisible or irrelevant icon focusable, it creates a keyboard navigation trap and confuses screen readers. Also, when filtering lists with Svelte reactive statements, an explicit 'else' branch is required to revert the list when the input becomes empty.
+**Action:** Always wrap trailing/clear icons in `{#if value !== ''}` and bind structural props (like `withTrailingIcon`) to the same condition. Ensure filtering reactive statements include fallback logic for empty states.

--- a/.svelte-kit/tsconfig.json
+++ b/.svelte-kit/tsconfig.json
@@ -9,6 +9,9 @@
 			],
 			"$lib/*": [
 				"../src/lib/*"
+			],
+			"$app/types": [
+				"./types/index.d.ts"
 			]
 		},
 		"rootDirs": [
@@ -25,7 +28,10 @@
 		"moduleResolution": "bundler",
 		"module": "esnext",
 		"noEmit": true,
-		"target": "esnext"
+		"target": "esnext",
+		"types": [
+			"node"
+		]
 	},
 	"include": [
 		"ambient.d.ts",
@@ -36,6 +42,9 @@
 		"../src/**/*.js",
 		"../src/**/*.ts",
 		"../src/**/*.svelte",
+		"../test/**/*.js",
+		"../test/**/*.ts",
+		"../test/**/*.svelte",
 		"../tests/**/*.js",
 		"../tests/**/*.ts",
 		"../tests/**/*.svelte"

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 **What:**
- Conditionally render the "clear search" icon based on search input context.
- Update structural property `withTrailingIcon` to dynamically scale UI layout.
- Fix logic regression where resetting input via keyboard backspace left search list state trapped on previous result sets.

🎯 **Why:**
Previously, the "cancel" trailing icon on the profile page domain search was focusable even when the input was empty, creating a focus trap and confusing screen reader state, as there was nothing to cancel. Further, clearing the input field using the backspace key failed to reset the filtered list to display all domains because the Svelte reactive block lacked an `else` branch.

📸 **Before/After:**
*Before:* Empty field contains 'cancel' focusable button.
*After:* Empty field hides close icon until query begins.

♿ **Accessibility:**
Changed generic "cancel" aria-label to a descriptive "clear search" label. Removed redundant un-actionable tab stops by hiding empty state trailing icons.

---
*PR created automatically by Jules for task [12795472250557735869](https://jules.google.com/task/12795472250557735869) started by @yeboster*