### PR TITLE
🎨 Palette: Profile Search Bar UX Improvements

### DIFF
--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
**💡 What:** 
Improved the UX of the search bar on the profile page by conditionally hiding the clear button when the input is empty and updating its ARIA label to be more descriptive. Also fixed a bug where the domain list wouldn't reset when clearing the search input via the keyboard (e.g., using backspace).

**🎯 Why:**
A clear button is unnecessary when the search input is empty, and hiding it provides a cleaner UI. The previous ARIA label ("cancel") was not descriptive enough for screen readers. The bug fix ensures the search filtering behaves intuitively.

**♿ Accessibility:**
Updated the clear button's `aria-label` from "cancel" to "clear search".

**📸 Before/After:**
*   **Before:** The "cancel" button (X icon) was always visible in the search bar, even when empty. Clearing the text with the keyboard did not reset the domains list.
*   **After:** The "clear search" button only appears when the user types in the search bar. Clearing the text properly resets the list of domains.

---
*PR created automatically by Jules for task [1696243017530843840](https://jules.google.com/task/1696243017530843840) started by @yeboster*