### PR TITLE
🎨 Palette: [UX improvement] Fix search reset logic & clear button accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,6 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+## 2026-05-15 - Svelte Reactive Reset & Conditional A11y
+**Learning:** Reactive filters in Svelte (e.g. `$: if (search) { filter() }`) must include an `else` block to reset state, otherwise clearing the input leaves stale data. Furthermore, decorative or conditional UI elements like "clear search" trailing icons should be wrapped in `{#if}` blocks to prevent screen readers from focusing them when they're conceptually hidden.
+**Action:** Always provide an `else` reset for reactive state derivations and structurally hide focusable elements using `{#if}` when they logically shouldn't exist, updating their `aria-label` to be descriptive.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 **What:** 
- Added an `else` block to the reactive domains filter to properly reset the list when the user clears their search input.
- Conditionally render the trailing clear icon in the search `Textfield` so it only appears when there's text to clear.
- Changed the icon's `aria-label` from "cancel" to "clear search".
- Also added a missing `return false;` explicitly in the `isFuzzyMatch` function.

🎯 **Why:** 
Previously, clearing the search input (via backspace) would leave the domains list permanently filtered because the reactive statement had no reset logic. Furthermore, the "clear" button was always focusable by screen readers even when the search bar was empty, creating a confusing and unnecessary tab stop. 

♿ **Accessibility:**
- Prevented keyboard focus on an inactive/invisible button by structurally wrapping it in `{#if}`.
- Replaced the vague "cancel" label with a more descriptive action "clear search" to improve clarity for screen reader users.

---
*PR created automatically by Jules for task [9017864604664995514](https://jules.google.com/task/9017864604664995514) started by @yeboster*