### PR TITLE
🎨 Palette: [UX improvement] Enhance search bar accessibility and reset logic

### DIFF
--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
### 💡 What
- Fixed the reactive filter block to include an `else` branch, meaning `domainsFiltered` properly resets to all domains when the user completely clears the input field via keyboard (e.g. Backspace).
- Wrapped the clear `<IconButton>` in a conditional `{#if search !== ''}` block so the clear button is dynamically rendered instead of always existing in the DOM.
- Bound the `Textfield`'s `withTrailingIcon` attribute to the `search !== ''` condition for accurate visual layout rendering.
- Changed the ARIA label of the clear button from `"cancel"` to `"clear search"` to provide clarity to screen-reader users.

### 🎯 Why
- Before this change, backspacing the entire search string would cause the reactive block to do nothing, stranding the user with stale filtered results even though the input field was empty. 
- Keeping invisible, non-functional icons in the DOM traps keyboard focus and causes confusion, making forms harder to navigate for those using screen readers.
- "Cancel" is a generic action that usually implies backing out of a form state; "clear search" explicitly tells visually impaired users exactly what the button does.

### ♿ Accessibility
- Prevents keyboard users from tabbing into a hidden icon element.
- Provides a clearer intention for screen reader users via specific ARIA labels.

---
*PR created automatically by Jules for task [14199432507110035431](https://jules.google.com/task/14199432507110035431) started by @yeboster*