### PR TITLE
🎨 Palette: [UX improvement] Conditional input clear button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,6 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+## 2024-05-19 - Ensure conditional elements inside inputs don't leave dead focus stops
+**Learning:** When rendering a clear icon inside SMUI textfields, the empty element is still part of the tab sequence. We also need to conditionally disable the padding.
+**Action:** Wrap the icon button inside `{#if value !== ''}` and dynamically set `withTrailingIcon={value !== ''}`.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -39,7 +39,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +55,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 What: Conditionally render the input clear button in text fields.
🎯 Why: Prevents dead tab stops during keyboard navigation when there is no text to clear, and improves ARIA labels.
📸 Before/After: Before, an empty search input would have an invisible stop that could be focused. After, the button only appears when there is text to clear.
♿ Accessibility: Updates `aria-label` from "cancel" to "clear search" to be more descriptive, and removes focus from empty elements.

---
*PR created automatically by Jules for task [6158139883932641148](https://jules.google.com/task/6158139883932641148) started by @yeboster*