### PR TITLE
⚡ Bolt: Optimize array lookup in proposals/voters endpoints

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 
 **Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
 **Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.
+
+## 2026-05-20 - Optimize Array Lookups using Sets
+**Learning:** When performing `.filter(item => !lookupArray.includes(item))`, the time complexity is O(N * M), which is an inefficient pattern, particularly for larger arrays such as API domain endpoints that deal with domain owners and voters. Converting the `lookupArray` to a `Set` and utilizing `Set.has()` changes this complexity to an optimal O(N) since Set lookups are O(1). Additionally, when this array-to-Set performance optimization is needed, it must be symmetrically applied to related endpoints (e.g., both the `add` and `remove` voters endpoints) to maintain uniform codebase efficiency.
+**Action:** When filtering arrays against another array in list management API endpoints, always convert the lookup array into a `Set` before the loop to optimize O(N * M) performance to O(N). Also, identify and apply symmetrical performance optimizations to related endpoints.

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,7 @@ node_modules
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+
+# Ignore Jules agent directories
+.jules
+.Jules

--- a/src/routes/api/proposals/voters/add/+server.ts
+++ b/src/routes/api/proposals/voters/add/+server.ts
@@ -23,7 +23,9 @@ export async function GET() {
 			?.setValue()
 			.values.map((voter) => voter.addressValue().value.toString('hex')) ?? [];
 
-	const newVoters = owners.filter((owner) => !voters.includes(owner)).slice(0, 50);
+	// Use Set for O(1) lookup performance
+	const votersSet = new Set(voters);
+	const newVoters = owners.filter((owner) => !votersSet.has(owner)).slice(0, 50);
 	if (newVoters.length === 0) return json({ newVoters }, { status: 200 });
 
 	const votingContract = await metaNamesSdk.contractRepository.getContract({

--- a/src/routes/api/proposals/voters/remove/+server.ts
+++ b/src/routes/api/proposals/voters/remove/+server.ts
@@ -25,7 +25,9 @@ export async function GET() {
 			?.setValue()
 			.values.map((voter) => voter.addressValue().value.toString('hex')) ?? [];
 
-	const votersToRemove = voters.filter((voter) => !owners.includes(voter)).slice(0, 50);
+	// Use Set for O(1) lookup performance
+	const ownersSet = new Set(owners);
+	const votersToRemove = voters.filter((voter) => !ownersSet.has(voter)).slice(0, 50);
 	if (votersToRemove.length === 0) return json({ newVoters: votersToRemove }, { status: 200 });
 
 	const votingContract = await metaNamesSdk.contractRepository.getContract({


### PR DESCRIPTION
💡 What: Converted the `voters` and `owners` arrays into `Set`s before running `.filter()` logic in the `/api/proposals/voters/add` and `remove` endpoints, replacing `Array.includes()` with `Set.has()`.

🎯 Why: To solve an O(N * M) performance bottleneck when comparing arrays representing domain owners and voters, as `Array.includes()` is O(N) while `Set.has()` is O(1).

📊 Impact: Reduces time complexity from O(N * M) to O(N). For large datasets (e.g. thousands of owners and voters), this will significantly improve API response times and reduce CPU consumption during array filtering operations on these endpoints.

🔬 Measurement: 
To verify the improvement, run unit tests to ensure no regressions, then measure API response times or CPU utilization for the `/api/proposals/voters/add` and `remove` endpoints before and after the change using performance profiling tools when scaling the mock data.

---
*PR created automatically by Jules for task [4355648915015147682](https://jules.google.com/task/4355648915015147682) started by @yeboster*