### PR TITLE
🎨 Palette: [UX improvement] Enhance profile search clear button behavior

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,5 @@ node_modules
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+.Jules/palette.md
+static/

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
### 💡 What
- Dynamically hides the clear icon button in the `src/routes/profile/+page.svelte` search bar when the input is empty.
- Adds an `else` block to the reactive search statement so the domain list resets to the full unfiltered list when the input is cleared.
- Updates the `.prettierignore` file to include `.Jules/palette.md` and the `static/` directory to prevent formatting collisions.

### 🎯 Why
- **UX:** Showing a "clear" button on an already empty search input is confusing and clutters the UI unnecessarily. Hiding it provides a cleaner, more intuitive interaction pattern.
- **Functionality:** The previous reactive statement `$: if (search !== '') { ... }` lacked an `else` branch, meaning clearing the text via backspace left the list in its previous filtered state rather than restoring all domains.
- **Maintenance:** Adding generated/agent files to `.prettierignore` keeps future PRs clean from unintended auto-formatting noise.

### 📸 Before/After
*(Visual verification was performed via Playwright script mocking the `Textfield` states. See `profile_page.png` artifact attached in the session for the "Filled" vs "Empty" state).*
- **Before:** The clear (cancel) icon was always visible inside the search bar, regardless of input state.
- **After:** The clear icon now only appears when `search !== ''`.

### ♿ Accessibility
- Updated the generic `aria-label="cancel"` on the clear `IconButton` to `aria-label="clear search"` to provide precise, descriptive context to screen reader users about the button's explicit action.
- By conditionally rendering the icon container (`{#if search !== ''}`), the clear button is entirely removed from the DOM and tab order when the input is empty, preventing keyboard users from tabbing to a redundant action.

---
*PR created automatically by Jules for task [15837628699164541562](https://jules.google.com/task/15837628699164541562) started by @yeboster*