### PR TITLE
🎨 Palette: [UX improvement] Search textfield focus accessibility and list reset logic

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+
+## 2024-05-22 - Proper Textfield Search UX/Accessibility
+**Learning:** Svelte reactive statements need explicit `else` clauses for UI states like search results filtering. Without it, when the search input gets cleared, the initial state won't reset. Conditionally rendering a trailing icon inside an SMUI `Textfield` must also dynamically bind `withTrailingIcon` and the inner `#if` block using the same condition so it isn't focusable when hidden. The aria-label should also be descriptive, e.g. 'clear search'.
+**Action:** Always provide else fallbacks on filtered lists. Always sync trailing icon attributes to visibility logic to avoid invisible focus stops.

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,7 @@ node_modules
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+
+.jules
+.Jules
+static/

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 **What:** 
- Updated the reactive statement in `+page.svelte` to properly reset the list state when the search input is empty. 
- Bound the `withTrailingIcon` attribute dynamically to search input state. 
- Wrapped the trailing icon slot in an `#if` block. 
- Updated the aria-label to a more descriptive "clear search".

🎯 **Why:** 
When the user clears their input using keyboard shortcuts (like backspace/delete), the domains list did not reset, forcing users to refresh. In addition, the cancel icon's invisible layout node was still focusable, harming accessibility.

📸 **Before/After:** No visual changes when searching, but the domains list now resets properly, and invisible trailing icons are no longer focusable.

♿ **Accessibility:**
- The trailing clear icon is no longer focusable when invisible/empty.
- The screen reader announces "clear search" instead of "cancel" to provide better context.

---
*PR created automatically by Jules for task [1331651013632202901](https://jules.google.com/task/1331651013632202901) started by @yeboster*