### PR TITLE
⚡ Bolt: [performance improvement] optimize debounce on domain search

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 
 **Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
 **Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.
+## 2024-05-24 - Unnecessary delayed searches on clear
+**Learning:** Setting up delayed setTimeout API calls via `debounce` when search inputs are emptied causes unnecessary component updates and unneeded closure memory allocation, especially when they will just instantly abort.
+**Action:** In search/filter debounce logic, always immediately short-circuit and perform state resets when the input becomes empty or invalid to prevent the async timer overhead.

--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -23,12 +23,19 @@
 	$: nameSearchedLabel = nameSearched ? `${nameSearched}.${$metaNamesSdk.config.tld}` : null;
 
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	function debounce(_domainName: string) {
+	function debounce(_domainName: string, _invalid: boolean) {
 		clearTimeout(debounceTimer);
+		if (_domainName === '' || _invalid) {
+			domain = undefined;
+			isLoading = false;
+			nameSearched = '';
+			++requestId;
+			return;
+		}
 		debounceTimer = setTimeout(async () => await search(), 400);
 	}
 
-	$: debounce(domainName);
+	$: debounce(domainName, invalid);
 
 	async function search(submit = false) {
 		if (invalid) return;


### PR DESCRIPTION
💡 **What:** Modified the `debounce` function in `DomainSearch.svelte` to immediately check if the `domainName` is empty or invalid. If so, it instantly resets the component state (`domain`, `isLoading`, `nameSearched`) and increments the `requestId` without ever setting up the `setTimeout` for a network call.

🎯 **Why:** Previously, clearing the search box still triggered the `setTimeout` to queue up an async `search()` call 400ms later. That call would execute, only to realize the input was empty and return early. This introduces unnecessary Javascript macro-task overhead, prevents instantaneous UI updates (resetting), and could theoretically fire duplicate aborted network calls if race conditions occur.

📊 **Impact:** Instant UI reset when clearing input (0ms vs 400ms delay). Completely eliminates unnecessary `setTimeout` and closure allocations when clearing the input or typing invalid characters.

🔬 **Measurement:** Open the Domain Search, type a query, and then rapidly erase the query (e.g. holding backspace). The UI will instantly revert to its default state instead of waiting 400ms for the debounce timer to clear the state. Verify unit tests pass.

---
*PR created automatically by Jules for task [11634097035782366142](https://jules.google.com/task/11634097035782366142) started by @yeboster*