### PR TITLE
🎨 Palette: [UX improvement] Fix profile domain search behavior and accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,9 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+
+## 2026-05-24 - Conditionally render trailing clear icons in SMUI Textfields
+
+**Learning:** When adding a clear button as a trailing icon to an SMUI Textfield, it shouldn't just be visually hidden or left in place when the input is empty. If it remains in the DOM, it's still focusable by keyboard navigation, which confuses users since clicking 'clear' on an empty input does nothing. Furthermore, reactive statements filtering based on search text (e.g. `$: if (search !== '')`) won't reset the list if the user simply deletes the query with the keyboard unless an `else` branch is provided.
+
+**Action:** Always wrap the trailing icon content in an `{#if search !== ''}` block, dynamically bind the textfield's `withTrailingIcon={search !== ''}` property so layout updates appropriately, and ensure reactive filters include an `else` clause that resets the filtered list back to the original list. Also, use a descriptive ARIA label like 'clear search' instead of 'cancel'.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 **What:** 
- Updated the reactive `search` filter to include an `else` branch, resetting the list properly when an input is cleared entirely.
- Dynamically bounds the `withTrailingIcon` property and hid the trailing clear button icon when the search input is empty.

🎯 **Why:** 
Previously, clearing the profile domains search input with the keyboard would not reset the displayed domains. Additionally, having a visually hidden or visibly non-functional 'clear' icon present inside an empty Textfield creates a confusing, focusable tab-stop for keyboard navigation. 

♿ **Accessibility:** 
- The clear icon button is conditionally removed from the DOM when empty, keeping focus restricted to interactive elements.
- ARIA label on the button improved from generic 'cancel' to 'clear search'.

---
*PR created automatically by Jules for task [13473171407083498665](https://jules.google.com/task/13473171407083498665) started by @yeboster*