### PR TITLE
⚡ Bolt: [performance improvement] Optimize getStats using Promise.all

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 
 **Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
 **Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.
+## 2024-11-23 - Async API Concurrency
+**Learning:** Sequential awaits on independent database/API calls (like in `getStats`) create artificial performance bottlenecks, effectively adding up response times unnecessarily.
+**Action:** Always use `Promise.all()` to run independent asynchronous operations concurrently to reduce total execution time to the maximum of the individual operations.

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -44,11 +44,12 @@ export interface DomainStats {
 }
 
 export const getStats = async (): Promise<DomainStats> => {
-	const domainCount = await metaNamesSdk.domainRepository.count();
-	const ownerCount = await metaNamesSdk.domainRepository
-		.getOwners()
-		.then((owners) => owners.length);
-	const recentDomains = await getRecentDomains();
+	// ⚡ Bolt optimization: Use Promise.all to fetch stats concurrently
+	const [domainCount, ownerCount, recentDomains] = await Promise.all([
+		metaNamesSdk.domainRepository.count(),
+		metaNamesSdk.domainRepository.getOwners().then((owners) => owners.length),
+		getRecentDomains()
+	]);
 
 	return {
 		domainCount,


### PR DESCRIPTION
💡 What: Replaced sequential await calls with `Promise.all` in `getStats`.
🎯 Why: To reduce the response time of the `/api/domains/stats` endpoint by fetching data concurrently.
📊 Impact: The response time is reduced from T(count) + T(owners) + T(recent) to max(T(count), T(owners), T(recent)).
🔬 Measurement: Verify the response time of the `/api/domains/stats` endpoint.

---
*PR created automatically by Jules for task [14811941351976293871](https://jules.google.com/task/14811941351976293871) started by @yeboster*