### PR TITLE
🎨 Palette: [UX improvement] Enhance search input interactivity and accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+
+## 2024-10-25 - Trailing Icons in SMUI Textfields
+**Learning:** When conditionally displaying trailing icons (like a clear button) in an SMUI Textfield, ensuring the component's `withTrailingIcon` property matches the condition is critical for layout to update correctly. Furthermore, invisible or empty icons remain focusable by screenreaders and keyboards if not conditionally rendered out using `{#if}` blocks.
+**Action:** Always wrap trailing icons inside a conditionally rendered block (`{#if search !== ''}`) and dynamically bind `withTrailingIcon` to the exact same condition. Additionally, apply a descriptive `aria-label` like "clear search" to replace generic terms like "cancel".

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
### 💡 What:
- Fixed the search input to correctly reset the domains list when cleared via keyboard.
- Updated the clear button to conditionally render only when there is input, dynamically updating the SMUI layout `withTrailingIcon` state.
- Updated the clear button's `aria-label` from `"cancel"` to `"clear search"`.

### 🎯 Why:
Empty trailing icons shouldn't remain keyboard focusable or announced by screen readers. Furthermore, the search component previously failed to restore the original domains list when a user highlighted the query and hit `backspace` or `delete`. 

### ♿ Accessibility:
Ensured the clear icon is removed from the focus order and accessibility tree when empty. Replaced the generic "cancel" ARIA label with an explicit action.

---
*PR created automatically by Jules for task [15067967617046228217](https://jules.google.com/task/15067967617046228217) started by @yeboster*