### PR TITLE
🎨 Palette: [Fix Profile Search Reactivity & Clear Button Accessibility]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,9 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.
+
+## 2026-05-26 - Accessible Clear Buttons in Search Inputs
+
+**Learning:** Conditionally rendering a trailing icon (like a clear button) inside an SMUI `Textfield` component requires dynamically binding the `withTrailingIcon` property to the same condition so layout updates correctly. Otherwise, an empty search input might maintain a trailing icon layout with a hidden button. Additionally, the clear button should have a descriptive `aria-label` (e.g., 'clear search' instead of 'cancel') and should only be rendered when the input has value so that keyboard users aren't forced to focus on a hidden/inactive button.
+**Action:** Use `withTrailingIcon={search !== ''}` when conditionally rendering trailing icons in SMUI Textfields, ensure conditionally rendered clear buttons are inside an `{#if search !== ''}` block, and use descriptive `aria-label`s like 'clear search'.

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,5 @@ node_modules
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+static/
+test-results/

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 **What:** 
- Updated the search reactivity in `src/routes/profile/+page.svelte` to include an `else` clause that properly resets `domainsFiltered` when the user deletes input down to an empty string.
- Conditionally rendered the clear button itself (`{#if search !== ''}`) to hide it completely when empty instead of just disabling it.
- Bound the `withTrailingIcon` attribute dynamically to `{search !== ''}` on the Textfield.
- Changed the `aria-label` of the clear button from `"cancel"` to `"clear search"` for improved screen reader semantics.
- Appended a learning log in `.jules/palette.md`.

🎯 **Why:** 
- Previously, clearing the input via keyboard did not restore the domains list because the reactive block had no `else` condition. 
- Screen reader users were prompted with an unusable "cancel" button when the search bar was completely empty, creating noise and confusion.

📸 **Before/After:** No visual difference when typed (both display an icon), but the 'x' button is completely inaccessible via keyboard or screen reader when the input is empty.

♿ **Accessibility:** 
- Removed a meaningless interactive element (the clear button) from the focus order and screen reader interpretation when there is nothing to clear.
- Improved clarity with descriptive `aria-label`s.

---
*PR created automatically by Jules for task [11739121811082904774](https://jules.google.com/task/11739121811082904774) started by @yeboster*