### PR TITLE
⚡ Bolt: Replace O(N*M) Array.includes loop with O(N+M) Set.has in API

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,8 @@
 
 **Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
 **Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.
+
+## 2026-05-27 - Array.includes() in API Endpoints
+
+**Learning:** Filtering arrays against other arrays using `.includes()` creates an O(N\*M) performance bottleneck, which is especially noticeable in APIs processing large lists (e.g. voters vs owners).
+**Action:** Always convert the target array into a `Set` (O(N) operation) and use `.has()` for O(1) lookups during filtering to achieve overall O(N+M) time complexity.

--- a/src/routes/api/proposals/voters/add/+server.ts
+++ b/src/routes/api/proposals/voters/add/+server.ts
@@ -23,7 +23,8 @@ export async function GET() {
 			?.setValue()
 			.values.map((voter) => voter.addressValue().value.toString('hex')) ?? [];
 
-	const newVoters = owners.filter((owner) => !voters.includes(owner)).slice(0, 50);
+	const votersSet = new Set(voters);
+	const newVoters = owners.filter((owner) => !votersSet.has(owner)).slice(0, 50);
 	if (newVoters.length === 0) return json({ newVoters }, { status: 200 });
 
 	const votingContract = await metaNamesSdk.contractRepository.getContract({

--- a/src/routes/api/proposals/voters/remove/+server.ts
+++ b/src/routes/api/proposals/voters/remove/+server.ts
@@ -25,7 +25,8 @@ export async function GET() {
 			?.setValue()
 			.values.map((voter) => voter.addressValue().value.toString('hex')) ?? [];
 
-	const votersToRemove = voters.filter((voter) => !owners.includes(voter)).slice(0, 50);
+	const ownersSet = new Set(owners);
+	const votersToRemove = voters.filter((voter) => !ownersSet.has(voter)).slice(0, 50);
 	if (votersToRemove.length === 0) return json({ newVoters: votersToRemove }, { status: 200 });
 
 	const votingContract = await metaNamesSdk.contractRepository.getContract({


### PR DESCRIPTION
💡 What: Replaced `Array.includes()` with `Set.has()` when filtering `owners` against `voters` (and vice-versa) in the proposal endpoints.
🎯 Why: `Array.includes()` inside a `.filter()` callback results in an $O(N \times M)$ nested loop, creating a performance bottleneck as the list of owners/voters grows.
📊 Impact: Reduces time complexity from $O(N \times M)$ to $O(N+M)$, ensuring server CPU time scales linearly rather than quadratically with user adoption.
🔬 Measurement: Verify by reviewing `src/routes/api/proposals/voters/add/+server.ts` and `remove/+server.ts`. Run unit tests with `pnpm test:unit --run` to ensure existing behavior remains perfectly intact due to strict equality checks matching array behavior.

---
*PR created automatically by Jules for task [4986066406904256899](https://jules.google.com/task/4986066406904256899) started by @yeboster*