### PR TITLE
⚡ Bolt: [performance improvement] optimize domain search debouncing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 
 **Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
 **Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.
+## 2025-02-27 - Svelte Debounce Early Return
+**Learning:** In Svelte input debouncing using `setTimeout`, failing to immediately reset stale results and loading state when the input becomes empty or invalid leads to unneccessary timeouts and a sluggish UI feel.
+**Action:** Always implement an early return in the debounce function to instantly clear the timer, reset state, and prevent redundant API fetches when the input is invalid or cleared.

--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -25,6 +25,16 @@
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	function debounce(_domainName: string) {
 		clearTimeout(debounceTimer);
+
+		// ⚡ Bolt Optimization: Early return on empty or invalid input.
+		// Avoids scheduling unnecessary timers, prevents redundant API requests,
+		// and instantly clears stale domain and loading states to improve perceived performance.
+		if (_domainName === '' || invalid) {
+			domain = undefined;
+			isLoading = false;
+			requestId++;
+			return;
+		}
 		debounceTimer = setTimeout(async () => await search(), 400);
 	}
 


### PR DESCRIPTION
💡 What: Added an early return in `src/routes/DomainSearch.svelte`'s `debounce` function. If the domain name becomes empty or invalid, it immediately resets state (`domain = undefined; isLoading = false; requestId++`) and returns.

🎯 Why: The previous implementation would blindly schedule a 400ms timeout even if the input became empty or invalid, which meant the UI stalled for 400ms before doing nothing (since `search()` also has an early return). Instantly clearing the state gives a snappier user experience.

📊 Impact: Reduces useless timeout scheduling by 100% when clearing input, prevents race conditions on cleared input, and makes UI responsiveness instant (0ms instead of 400ms delay) when deleting the search term.

🔬 Measurement: Type a domain name, then rapidly select all and delete it. Observe the `isLoading` state and the previous search results disappearing instantly without a 400ms delay. Also verified by unit tests continuing to pass.

---
*PR created automatically by Jules for task [4017186550622344810](https://jules.google.com/task/4017186550622344810) started by @yeboster*