### PR TITLE
🎨 Palette: [UX improvement] Clearer search field interaction and accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.
+## 2024-05-30 - Contextual Trailing Icons and Descriptive ARIA Labels
+**Learning:** Clear buttons in search inputs should only be visually present and focusable when there is text to clear. Furthermore, generic labels like "cancel" are ambiguous for screen readers in the context of search inputs.
+**Action:** Conditionally render clear icons (e.g., `{#if search !== ''}`) to ensure they are omitted from the tab order when empty. Bind attributes like `withTrailingIcon` to the same condition to maintain layout, and always use descriptive action-oriented labels like "clear search".

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 **What:**
- Conditionally render the trailing "clear" icon on the search bar so it only appears when there is text to clear.
- Update `withTrailingIcon` to dynamically bind to the search state.
- Change the ARIA label from the generic "cancel" to the descriptive "clear search".
- Reset the `domainsFiltered` list correctly when the user clears the search input using backspace/delete instead of clicking the clear button.

🎯 **Why:**
- Screen reader users were reading an ambiguous "cancel" label for the clear button.
- Keyboard navigators were able to focus and tab to a clear button even when the input was completely empty.
- Clearing the search input via keyboard didn't restore the original domain list, leaving users stuck with filtered results.

♿ **Accessibility:**
- The clear button is completely removed from the DOM and tab order when irrelevant.
- "clear search" explicitly states the action for screen reader assistance.

---
*PR created automatically by Jules for task [14355438807514984381](https://jules.google.com/task/14355438807514984381) started by @yeboster*