### PR TITLE
⚡ Bolt: Optimize voter array filtering using O(1) Set lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,8 @@
 
 **Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
 **Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.
+
+## 2026-06-01 - Set-based Lookups for Array Filtering
+
+**Learning:** When filtering large arrays using `.includes()` against another array, the operation becomes O(N*M), which degrades performance as the dataset grows. This was observed in list filtering API endpoints (`voters/add` and `voters/remove`).
+**Action:** Always convert the lookup array into a `Set` to achieve O(1) lookups via `.has()`, reducing the time complexity of the filter operation to O(N).

--- a/src/routes/api/proposals/voters/add/+server.ts
+++ b/src/routes/api/proposals/voters/add/+server.ts
@@ -22,8 +22,10 @@ export async function GET() {
 			.get('voters')
 			?.setValue()
 			.values.map((voter) => voter.addressValue().value.toString('hex')) ?? [];
+	// O(1) lookup set
+	const votersSet = new Set(voters);
 
-	const newVoters = owners.filter((owner) => !voters.includes(owner)).slice(0, 50);
+	const newVoters = owners.filter((owner) => !votersSet.has(owner)).slice(0, 50);
 	if (newVoters.length === 0) return json({ newVoters }, { status: 200 });
 
 	const votingContract = await metaNamesSdk.contractRepository.getContract({

--- a/src/routes/api/proposals/voters/remove/+server.ts
+++ b/src/routes/api/proposals/voters/remove/+server.ts
@@ -19,13 +19,16 @@ export async function GET() {
 		return json({ error: 'Voting has ended' }, { status: 400 });
 
 	const owners = await metaNamesSdk.domainRepository.getOwners();
+	// O(1) lookup set
+	const ownersSet = new Set(owners);
+
 	const voters =
 		fields
 			.get('voters')
 			?.setValue()
 			.values.map((voter) => voter.addressValue().value.toString('hex')) ?? [];
 
-	const votersToRemove = voters.filter((voter) => !owners.includes(voter)).slice(0, 50);
+	const votersToRemove = voters.filter((voter) => !ownersSet.has(voter)).slice(0, 50);
 	if (votersToRemove.length === 0) return json({ newVoters: votersToRemove }, { status: 200 });
 
 	const votingContract = await metaNamesSdk.contractRepository.getContract({


### PR DESCRIPTION
### 💡 What
Converted the secondary lookup arrays into JavaScript `Set` instances in the `voters/add` and `voters/remove` API endpoints. This changes the array filtering logic from using `Array.prototype.includes()` to `Set.prototype.has()`.

### 🎯 Why
When filtering one large array against another, `.includes()` requires iterating through the lookup array for every item in the source array, resulting in an O(N*M) time complexity. By creating a `Set` first, the lookups become O(1), improving the overall filtering complexity to O(N). As the lists of owners and voters grow, this prevents significant CPU blocking on the server.

### 📊 Impact
Reduces the time complexity of the filtering operation from O(N*M) to O(N). This makes the `/api/proposals/voters/add` and `/api/proposals/voters/remove` endpoint times scale linearly rather than exponentially as the number of domain owners increases.

### 🔬 Measurement
Run `pnpm test:unit` to verify the logic remains intact. If you benchmark the endpoints locally with mock data containing >10,000 owners, you will see a significant reduction in blocking time.

---
*PR created automatically by Jules for task [2267377694452972982](https://jules.google.com/task/2267377694452972982) started by @yeboster*