### PR TITLE
🎨 Palette: Improve profile search UX and accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.
+## 2026-06-01 - Svelte search inputs UX
+**Learning:** When using Svelte reactive statements to filter lists based on search input, always include an 'else' clause to ensure the list resets when the input is empty. Also, when conditionally rendering a trailing icon inside an SMUI Textfield, ensure the icon element is conditionally rendered and dynamically bind the 'withTrailingIcon' property to the same condition. Finally use descriptive 'aria-label' for icon-only buttons.
+**Action:** Add an 'else' clause to reactive search filters, bind 'withTrailingIcon' dynamically, conditionally render the icon, and use descriptive 'aria-label'.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 What: Modified the profile domains list search bar to correctly reset search results on clear. Conditionally rendered the clear icon button to only appear when the search is active, and updated its `aria-label` to be more descriptive.

🎯 Why: To ensure that clearing the search with a keyboard (backspace/delete) properly restores the original list of domains. Additionally, it removes a pointless tab stop (the hidden clear button) and fixes its poor accessibility labeling for screen readers.

📸 Before/After: Not applicable (behavioral and screen-reader visual changes).

♿ Accessibility: Updated the generic `cancel` label to `clear search` on the search bar trailing icon button, and conditionally removed the element from the DOM when inactive to prevent keyboard users from focusing an invisible, non-functional button.

---
*PR created automatically by Jules for task [13891100709850771764](https://jules.google.com/task/13891100709850771764) started by @yeboster*