### PR TITLE
🎨 Palette: Clear search icon conditionally rendered and accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,6 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+## 2024-10-25 - Trailing Icons Accessibility
+**Learning:** When a trailing icon in a textfield (like a clear button) is empty, it can still be focusable and read as empty or 'cancel' by screen readers, creating a confusing experience.
+**Action:** Conditionally render the icon itself (e.g., `{#if search !== ''}`) so it is not focusable when empty. Dynamically bind `withTrailingIcon={search !== ''}` and use a descriptive `aria-label` like 'clear search'.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -55,14 +55,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 **What:**
- Conditionally render the "clear search" trailing icon in the search textfield.
- Bind the `withTrailingIcon` property dynamically so it updates according to the input state.
- Update the `aria-label` from "cancel" to a more descriptive "clear search".

🎯 **Why:**
When the search field is empty, the trailing icon should not be focusable or announced to screen readers. Conditionally rendering it ensures that users aren't confused by an empty or "cancel" action when there's nothing to clear.

📸 **Before/After:**
- **Before:** Empty search input has a trailing icon that can be focused with the tab key, and screen readers read it as "cancel".
- **After:** Trailing icon is hidden when empty. Once input is typed, it dynamically appears, is focusable, and is read as "clear search" by screen readers.

♿ **Accessibility:**
- Added `aria-label="clear search"` for a clear description.
- Removed keyboard focus trap by conditionally rendering the element.

---
*PR created automatically by Jules for task [11399314536354977529](https://jules.google.com/task/11399314536354977529) started by @yeboster*