### PR TITLE
🎨 Palette: [UX improvement] Fix search filter clear button UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.
+## 2024-10-25 - Conditional Focusability and ARIA Labels for Clear Buttons
+**Learning:** In Svelte components using SMUI, trailing icons (like "clear search" buttons) should be conditionally rendered (not just functionally disabled) when the input is empty so they are removed from the DOM and cannot receive focus. Also, an \`aria-label\` of "cancel" is too generic for a clear input action; "clear search" is much better for screen readers.
+**Action:** Conditionally render clear buttons inside their slots (\`{#if search !== ''}\`), conditionally bind the wrapper property (\`withTrailingIcon={search !== ''}\`), and use descriptive action verbs for ARIA labels.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 **What:** Fixed the search filter logic to properly reset when the input is cleared, conditionally removed the "clear" trailing icon when the input is empty so it's unfocusable, and changed the ARIA label to "clear search".

🎯 **Why:** Previously, clearing the search string manually left the domains list filtered instead of restoring the original list. The "cancel" button was also focusable even when there was nothing to clear, adding unnecessary tab stops for keyboard users. The "cancel" ARIA label was too generic.

📸 **Before/After:** No visible screenshot changes except the clear icon now hides seamlessly.

♿ **Accessibility:**
- Added `{#if search !== ''}` to the trailing icon slot and dynamically bound the `withTrailingIcon` attribute. This removes the button entirely from the DOM and tab order when the search box is empty.
- Changed `aria-label="cancel"` to `aria-label="clear search"` for improved screen reader context.

---
*PR created automatically by Jules for task [16728103141099685151](https://jules.google.com/task/16728103141099685151) started by @yeboster*