### PR TITLE
⚡ Bolt: [performance improvement] Optimize domain search debouncing

### DIFF
--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -22,9 +22,19 @@
 	$: invalid = domainName !== '' && !validator.validate(domainName, { raiseError: false });
 	$: nameSearchedLabel = nameSearched ? `${nameSearched}.${$metaNamesSdk.config.tld}` : null;
 
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	function debounce(_domainName: string) {
 		clearTimeout(debounceTimer);
+
+		// Performance optimization: Reset state and skip scheduling a search API call if the input is empty or invalid.
+		// This prevents stale network requests and unnecessary UI loading states.
+		if (_domainName === '' || invalid) {
+			domain = undefined;
+			nameSearched = '';
+			isLoading = false;
+			requestId++;
+			return;
+		}
+
 		debounceTimer = setTimeout(async () => await search(), 400);
 	}
 


### PR DESCRIPTION
💡 What: Optimized the `debounce` function in `DomainSearch.svelte` to add an early return and state reset if the search input becomes empty or invalid.

🎯 Why: Previously, navigating away or clearing the search input would still unnecessarily schedule a `setTimeout` for the search API call, causing unnecessary network activity, potential race conditions, and brief UI loading flashes. By resetting the state eagerly and aborting the scheduled call, we prevent stale API requests.

📊 Impact: Reduces CPU cycles and unnecessary network requests on empty/invalid queries.

🔬 Measurement: Verified locally using component tests and visual inspection. Clearing an invalid search input now no longer results in an orphaned fetch request.

---
*PR created automatically by Jules for task [8586826066379739191](https://jules.google.com/task/8586826066379739191) started by @yeboster*