### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,8 @@
 
 **Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
 **Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.
+
+## 2024-10-31 - Debouncing Empty Inputs
+
+**Learning:** When users quickly clear a search input, standard `setTimeout` debouncing still triggers after the delay, wasting API calls and potentially displaying stale UI states if the async operation doesn't cleanly abort on empty strings.
+**Action:** When debouncing search inputs, immediately intercept an empty value (`""`) to clear the timeout, reset UI state, and invalidate any pending `requestId` to prevent unnecessary execution and reduce GC/network overhead.

--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -25,6 +25,16 @@
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	function debounce(_domainName: string) {
 		clearTimeout(debounceTimer);
+
+		// Performance optimization: when input is cleared, immediately reset
+		// state and cancel any in-flight searches via requestId.
+		if (_domainName === '') {
+			domain = undefined;
+			isLoading = false;
+			requestId++;
+			return;
+		}
+
 		debounceTimer = setTimeout(async () => await search(), 400);
 	}
 


### PR DESCRIPTION
💡 **What:** Optimized the `debounce` function in `src/routes/DomainSearch.svelte` to intercept an empty input (`_domainName === ''`). When intercepted, it immediately clears the timeout, resets the UI state (`domain`, `isLoading`), and skips any further search scheduling while aborting the current in-flight search via the `requestId` increment.

🎯 **Why:** When users quickly clear the search input, the standard Svelte debouncing setup previously scheduled a 400ms timeout for a `search()` call anyway. The `search()` function would hit an early return `if (domainName === '') return;`, but this wouldn't clear the pending `requestId` nor reset the UI state back to idle, wasting CPU cycles and potentially causing stale async outcomes to overwrite correct state.

📊 **Impact:** 
- Eliminates 1 unnecessary `setTimeout` per cleared input action.
- Instantly cleans up UI loading states (0ms instead of 400ms delay).
- Prevents stale HTTP search request responses from resolving after an input is cleared.

🔬 **Measurement:** Verify by typing a domain in the input, immediately deleting it completely, and observing that `isLoading` stops immediately rather than dangling for an extra 400ms. Unit tests for `DomainSearch.svelte` or Svelte logic can confirm standard functionality is unbroken.

---
*PR created automatically by Jules for task [16194605511881786611](https://jules.google.com/task/16194605511881786611) started by @yeboster*