### PR TITLE
🎨 Palette: [UX improvement] - Improve profile search accessibility and state

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,9 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.
+
+## 2026-06-04 - Search input trailing icon accessibility and state fallback
+
+**Learning:** In Svelte Material UI (SMUI), trailing icons inside Textfields remain focusable even when empty, which can confuse screen reader users, and reactive Svelte arrays need explicit `else` block resets.
+**Action:** Always wrap `svelte:fragment slot="trailingIcon"` contents in an `{#if value !== ''}` and bind `withTrailingIcon={value !== ''}` to conditionally render the icon button, ensuring it is only accessible when the input has content. Also ensure reactive filtering blocks like `$: if (search !== '')` include an `else` branch to correctly reset data arrays to default.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 **What**:
- Improved the UX and accessibility of the domain search input on the profile page (`src/routes/profile/+page.svelte`).
- The clear trailing icon is now dynamically conditionally rendered, so it cannot receive keyboard focus or confuse screen reader users when the input is empty.
- Fixed a bug where clearing the search input via backspace left stale filtered results by adding an explicit `else` block to reset the state array to all domains.
- Updated the `aria-label` on the clear button to be more descriptive ("clear search" instead of "cancel").
- Fixed a bug in the `isFuzzyMatch` filter logic by properly returning false in the else condition.

🎯 **Why**:
- Accessible interactive elements are critical. A clear button shouldn't exist in the DOM or accessibility tree if there is nothing to clear. This reduces noise for screen reader users and improves keyboard navigation.
- The reactive state bug confused users by not returning to the full domain list when they deleted their query. 

♿ **Accessibility**:
- The "clear search" icon is completely removed from the DOM when empty, removing a tab-stop.
- Added a highly descriptive `aria-label` to the clear action.

---
*PR created automatically by Jules for task [291634064285324581](https://jules.google.com/task/291634064285324581) started by @yeboster*