### PR TITLE
⚡ Bolt: optimize debounce search to instantly clear on empty inputs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,8 @@
 
 **Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
 **Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.
+
+## 2024-10-25 - Svelte Debounce Search State Invalidation
+
+**Learning:** When using debounced inputs to trigger searches, failing to immediately abort or skip the debounce timeout when the input becomes empty or invalid leads to lingering UI states and wasted timeout allocations. The component must actively reset state variables (`domain`, `isLoading`, etc.) immediately within the debounce function when invalidity occurs, bypassing the timer entirely.
+**Action:** Always inject validation checks within `debounce()` functions, clearing pending timeouts and resetting relevant data states immediately for empty or invalid inputs before scheduling any async tasks.

--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -23,12 +23,19 @@
 	$: nameSearchedLabel = nameSearched ? `${nameSearched}.${$metaNamesSdk.config.tld}` : null;
 
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	function debounce(_domainName: string) {
+	function debounce(_domainName: string, _invalid: boolean) {
 		clearTimeout(debounceTimer);
+		if (_domainName === '' || _invalid) {
+			domain = undefined;
+			isLoading = false;
+			nameSearched = '';
+			requestId++;
+			return;
+		}
 		debounceTimer = setTimeout(async () => await search(), 400);
 	}
 
-	$: debounce(domainName);
+	$: debounce(domainName, invalid);
 
 	async function search(submit = false) {
 		if (invalid) return;


### PR DESCRIPTION
### 💡 What
Updated the `debounce` function in `DomainSearch.svelte` to properly handle empty or invalid inputs by immediately bypassing the timeout and resetting component state.

### 🎯 Why
Previously, when the user cleared the search input, a 400ms timer was still scheduled which then triggered `search()`, eventually returning because the input was empty. More importantly, the reactive states (like `domain`, `isLoading`, and `nameSearched`) were left lingering, causing potential stale results or visual lag. By immediately aborting on invalidation, we keep the UI instantly responsive and save CPU cycles.

### 📊 Impact
- Eliminates 1 unnecessary timeout creation per clear/invalid action.
- Instantly clears stale search states rather than relying on later conditional fall-throughs.
- Aborts pending outdated requests.

### 🔬 Measurement
Load the domain search page, type a domain name, and then quickly clear the input. The previous search results will instantly disappear, and no additional backend operations are initiated. Run `pnpm test:unit` to verify core behavior remains unbroken.

---
*PR created automatically by Jules for task [10689868327793415386](https://jules.google.com/task/10689868327793415386) started by @yeboster*