### PR TITLE
🎨 Palette: [Add ARIA attributes to Wallet Connect button]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,8 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.
+
+## 2024-10-25 - ARIA Attributes for Interactive Trigger Elements
+
+**Learning:** When using buttons as interactive trigger elements (like opening a menu or dropdown), it's crucial for accessibility to inform screen reader users about the button's behavior and current state. Missing these attributes can leave keyboard and screen reader users confused about what the button does or whether their action was successful.
+**Action:** Always add `aria-haspopup="menu"` (or the appropriate role, such as `listbox` or `dialog`) and bind `aria-expanded` to the component's open state variable for buttons that trigger popups or menus.

--- a/src/routes/WalletConnectButton.svelte
+++ b/src/routes/WalletConnectButton.svelte
@@ -97,7 +97,12 @@
 	export let connectButtonVariant: 'raised' | 'unelevated' | 'outlined' = 'raised';
 </script>
 
-<Button variant={connectButtonVariant} on:click={toggleMenu}>
+<Button
+	variant={connectButtonVariant}
+	on:click={toggleMenu}
+	aria-haspopup="menu"
+	aria-expanded={toggleOpen}
+>
 	<slot name="buttonLabel">Connect</slot>
 </Button>
 <Menu


### PR DESCRIPTION
💡 **What:** Added `aria-haspopup="menu"` and `aria-expanded={toggleOpen}` to the wallet connect trigger button in `WalletConnectButton.svelte`.
🎯 **Why:** To inform assistive technologies (like screen readers) that this button controls a popup menu and to communicate its current visibility state, resolving a micro-accessibility gap.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Screen reader users can now understand that the Connect Wallet button opens a menu and whether that menu is currently open or closed.

---
*PR created automatically by Jules for task [13205606667365909499](https://jules.google.com/task/13205606667365909499) started by @yeboster*