### PR TITLE
🎨 Palette: [UX improvement] Fix search field trailing icon and filter behavior

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,9 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.
+
+## 2024-10-24 - Conditionally Rendering Trailing Icons in SMUI Textfields
+
+**Learning:** When conditionally rendering a trailing icon (like a clear button) inside an SMUI `Textfield` component, the icon element itself must be conditionally rendered (e.g., `{#if search !== ''}`) so it is not focusable when empty. Furthermore, the `withTrailingIcon` property on the `Textfield` must be dynamically bound to the same condition (e.g., `withTrailingIcon={search !== ''}`) to ensure the layout updates correctly, and a descriptive `aria-label` (e.g., 'clear search' instead of 'cancel') must be provided.
+**Action:** Always conditionally render both the icon element and the `withTrailingIcon` property together to prevent inaccessible hidden focus states, and use descriptive ARIA labels.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 What: Add conditionally rendered trailing icon in search component and reset domain list correctly.
🎯 Why: Makes the UI cleaner by not displaying a "clear" button when there is nothing to clear. Prevents keyboard-navigating users from tabbing into an invisible icon. Fixes an active bug where deleting search text does not restore the full domains list.
📸 Before/After: Visual change limits the search icon visibility to active searches.
♿ Accessibility: Updates the clear button's generic "cancel" aria-label to a more descriptive "clear search" and removes an invisible focusable element when the search field is empty.

---
*PR created automatically by Jules for task [13289317991535296997](https://jules.google.com/task/13289317991535296997) started by @yeboster*