### PR TITLE
⚡ Bolt: Refactor DomainsTable sort to reduce GC overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,8 @@
 
 **Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
 **Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.
+
+## 2024-11-20 - GC Overhead in Array Sort
+
+**Learning:** Creating temporary arrays or using object destructuring inside an `Array.prototype.sort()` callback (e.g., `[a, b][condition ? 'slice' : 'reverse']()`) introduces heavy Garbage Collection overhead and slows down operations because the callback is executed $O(N \log N)$ times.
+**Action:** Refactor sorting logic to use straightforward scalar variable assignments and mathematical negations (e.g., `return condition ? comparison : -comparison`) for descending order to improve performance.

--- a/src/routes/profile/DomainsTable.svelte
+++ b/src/routes/profile/DomainsTable.svelte
@@ -29,11 +29,13 @@
 
 	function handleSort() {
 		domains.sort((a, b) => {
-			const [aVal, bVal] = [a[sort], b[sort]][
-				sortDirection === 'ascending' ? 'slice' : 'reverse'
-			]();
-			if (typeof aVal === 'string' && typeof bVal === 'string') return aVal.localeCompare(bVal);
-			return Number(aVal) - Number(bVal);
+			const aVal = a[sort];
+			const bVal = b[sort];
+			let comparison = 0;
+			if (typeof aVal === 'string' && typeof bVal === 'string')
+				comparison = aVal.localeCompare(bVal);
+			else comparison = Number(aVal) - Number(bVal);
+			return sortDirection === 'ascending' ? comparison : -comparison;
 		});
 		domains = domains;
 	}


### PR DESCRIPTION
💡 What: Replaced array destructuring and temporary array creations (`[a,b][condition?'slice':'reverse']()`) inside the `Array.prototype.sort()` callback in `src/routes/profile/DomainsTable.svelte` with scalar variable assignments and mathematical negation.

🎯 Why: The previous implementation created significant Garbage Collection (GC) overhead by allocating arrays on every callback iteration, which runs O(N log N) times during sorting. This negatively impacts frontend performance when sorting large domain lists.

📊 Impact: Reduces memory allocation and GC pauses during table sorting, resulting in smoother UI interactions, especially on lower-end devices or with large data sets.

🔬 Measurement: Verified by running unit tests (`pnpm test:unit --run`) and manually reviewing the sort behavior. The sorting functionality remains exactly the same while avoiding array allocation inside the hot loop.

---
*PR created automatically by Jules for task [10472302026023265873](https://jules.google.com/task/10472302026023265873) started by @yeboster*