### PR TITLE
🎨 Palette: [UX improvement] Fix conditionally rendered SMUI Textfield trailing icon a11y

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,9 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.
+
+## 2024-10-25 - Conditional Rendering of Interactive Elements inside Input Fields
+
+**Learning:** In SMUI `Textfield` components, unconditionally rendering trailing icons (like a "clear search" button) can result in these elements being incorrectly focusable when empty.
+**Action:** When conditionally rendering a trailing icon inside an SMUI `Textfield`, ensure the element itself is hidden (`{#if value !== ''}`) and dynamically bind `withTrailingIcon` to the same condition. Use descriptive `aria-labels` like "Clear search" rather than generic ones.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -39,7 +39,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +55,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="Clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 **What:**
Updated the Domain Search filtering input (`Textfield` component) in the Profile page to correctly conditionally render its `trailingIcon` only when the input has value.

🎯 **Why:**
The previous implementation unconditionally rendered the clear button but styled it in a way that made it inaccessible when empty, while still allowing it to be focusable via keyboard navigation. This meant users navigating via keyboard could focus a hidden, generic "cancel" button. It also fixed a minor logical bug where a `return` keyword was missing in the domain filtering logic (`else false;` updated to `else return false;`).

📸 **Before/After:**
- **Before:** Keyboard users tabbing through the page would focus an invisible element within the empty search field. Screen readers would read "cancel button".
- **After:** The clear button is completely removed from the DOM and focus tree when the input is empty. When populated, the screen reader correctly reads "Clear search button".

♿ **Accessibility:**
- The clear button is no longer focusable when empty.
- Improved the ARIA label from a generic `aria-label="cancel"` to `aria-label="Clear search"` to better reflect its function.

---
*PR created automatically by Jules for task [4118258702663007026](https://jules.google.com/task/4118258702663007026) started by @yeboster*