### PR TITLE
🎨 Palette: [UX improvement] Fix stale search UI states and improve clear button accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+
+## 2024-11-20 - Stale UI States in Search Filters
+**Learning:** Svelte reactive search filters and debounced inputs require explicit reset logic for empty states to prevent confusing stale UI results.
+**Action:** Always ensure an 'else' block or default reset path exists when an input becomes empty.

--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -25,6 +25,13 @@
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	function debounce(_domainName: string) {
 		clearTimeout(debounceTimer);
+		if (_domainName === '') {
+			domain = undefined;
+			nameSearched = '';
+			isLoading = false;
+			requestId++;
+			return;
+		}
 		debounceTimer = setTimeout(async () => await search(), 400);
 	}
 
@@ -70,7 +77,7 @@
 		>
 			<svelte:fragment slot="trailingIcon">
 				<div class="submit">
-					<IconButton aria-label="search">
+					<IconButton on:click={submit} aria-label="search">
 						<Icon icon="search" />
 					</IconButton>
 				</div>

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 What: Added explicit reset logic for Svelte reactive search filters and debounced search inputs. Conditionally rendered the clear search trailing icon and improved its accessibility label.
🎯 Why: Async buttons and search debouncers often leave confusing, stale UI states when a user clears the input quickly. This makes the interface feel unresponsive or broken. This PR ensures that empty input states instantly revert the UI to the expected clean state and cleans up focus trapping in empty icon buttons.
📸 Before/After: Visual changes are subtle (the clear icon disappears seamlessly rather than remaining as an empty trap), but the interaction flow is now deterministic.
♿ Accessibility: Updated the generic "cancel" aria-label on the search clear button to "clear search". Conditionally rendering the trailing icon slot ensures keyboard users cannot accidentally tab to an invisible, non-functional clear button when the search is empty.

---
*PR created automatically by Jules for task [6232185015609557018](https://jules.google.com/task/6232185015609557018) started by @yeboster*