### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,8 @@
 
 **Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
 **Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.
+
+## 2024-11-20 - Garbage Collection Overhead in Sorting Callbacks
+
+**Learning:** Destructuring and instantiating arrays within `Array.prototype.sort()` callbacks (e.g., `const [aVal, bVal] = [a[sort], b[sort]][sortDirection === 'ascending' ? 'slice' : 'reverse']();`) causes high garbage collection overhead and significantly slows down the sort operation, particularly on larger datasets.
+**Action:** Always refactor sorting logic to use scalar value assignments and standard localeCompare / numeric subtractions, using simple mathematical negation (`* 1` or `* -1`) to handle ascending and descending orders.

--- a/src/routes/profile/DomainsTable.svelte
+++ b/src/routes/profile/DomainsTable.svelte
@@ -29,11 +29,14 @@
 
 	function handleSort() {
 		domains.sort((a, b) => {
-			const [aVal, bVal] = [a[sort], b[sort]][
-				sortDirection === 'ascending' ? 'slice' : 'reverse'
-			]();
-			if (typeof aVal === 'string' && typeof bVal === 'string') return aVal.localeCompare(bVal);
-			return Number(aVal) - Number(bVal);
+			const aVal = a[sort];
+			const bVal = b[sort];
+			// Bolt Optimization: Avoiding array allocation & destructuring in sort comparison
+			// which reduces garbage collection overhead and makes sorting faster
+			const factor = sortDirection === 'ascending' ? 1 : -1;
+			if (typeof aVal === 'string' && typeof bVal === 'string')
+				return aVal.localeCompare(bVal) * factor;
+			return (Number(aVal) - Number(bVal)) * factor;
 		});
 		domains = domains;
 	}


### PR DESCRIPTION
💡 What: Replaced inline array instantiation/destructuring (`const [aVal, bVal] = [a[sort], ...`) inside the `Array.prototype.sort()` callback in `src/routes/profile/DomainsTable.svelte` with direct scalar value assignments and standard localeCompare / mathematical operations.

🎯 Why: Creating arrays on every single comparison tick of a sort operation incurs high garbage collection overhead and slows down the sort execution loop. For large lists of domains, this causes unnecessary main-thread blocking.

📊 Impact: Reduces sorting latency and entirely eliminates array allocations during the sort logic, resulting in faster and smoother re-ordering of the table when column headers are clicked.

🔬 Measurement: Profile the sorting logic performance with large arrays (>50 items) in Chrome DevTools to observe decreased GC times during sort. Run `pnpm test:unit --run` to ensure existing sort functionality works perfectly.

---
*PR created automatically by Jules for task [3608804950943718010](https://jules.google.com/task/3608804950943718010) started by @yeboster*