### PR TITLE
🎨 Palette: [Add clear button to Domain Search]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,9 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.
+
+## 2024-10-24 - Trailing Clear Icon for Textfield
+
+**Learning:** When adding a clear icon to an SMUI `Textfield` component to allow users to quickly reset debounced search input, conditionally rendering the inner `IconButton` based on whether the input string is empty (e.g. `{#if domainName !== ''}`) is insufficient because the outer `.mdc-text-field--with-trailing-icon` styling continues to reserve space and focusability for a now empty node.
+**Action:** Always dynamically bind the outer Svelte `withTrailingIcon` attribute directly to the emptiness condition (e.g. `withTrailingIcon={domainName !== ''}`) when conditionally rendering trailing icons inside the `Textfield` component to properly update its state and styling.

--- a/src/routes/DomainSearch.svelte
+++ b/src/routes/DomainSearch.svelte
@@ -25,6 +25,12 @@
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	function debounce(_domainName: string) {
 		clearTimeout(debounceTimer);
+		if (_domainName === '') {
+			domain = undefined;
+			nameSearched = '';
+			isLoading = false;
+			return;
+		}
 		debounceTimer = setTimeout(async () => await search(), 400);
 	}
 
@@ -65,15 +71,17 @@
 			bind:value={domainName}
 			bind:invalid
 			label="Domain name"
-			withTrailingIcon
+			withTrailingIcon={domainName !== ''}
 			autofocus
 		>
 			<svelte:fragment slot="trailingIcon">
-				<div class="submit">
-					<IconButton aria-label="search">
-						<Icon icon="search" />
-					</IconButton>
-				</div>
+				{#if domainName !== ''}
+					<div class="submit">
+						<IconButton aria-label="clear search" on:click={() => (domainName = '')}>
+							<Icon icon="clear" />
+						</IconButton>
+					</div>
+				{/if}
 			</svelte:fragment>
 			<svelte:fragment slot="helper">
 				{#if errors.length > 0}


### PR DESCRIPTION
**What:** 
Added a trailing 'clear' icon button to the `DomainSearch` component that immediately clears the input text state. Dynamically binds the Svelte `withTrailingIcon` attribute to the emptiness of the input string to reset reserved whitespace.

**Why:**
Allows users to quickly reset a debounced search input without holding backspace or selecting all text, which is a micro-UX enhancement that makes navigating domain availability much faster.

**Accessibility:**
The `IconButton` includes `aria-label="clear search"`, and the element unmounts (removing it from keyboard focus order) when the search is already empty to prevent ghost tabs.

---
*PR created automatically by Jules for task [8305108903614843902](https://jules.google.com/task/8305108903614843902) started by @yeboster*