### PR TITLE
🎨 Palette: [UX improvement] Domain search accessibility and state handling

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.
+
+## 2024-10-24 - Search Input Trailing Icons and State Resets
+**Learning:** When using SMUI `Textfield` components with a trailing clear icon, binding the icon's visibility solely via conditionally rendering the nested `<IconButton>` isn't enough; the parent `Textfield`'s `withTrailingIcon` prop must also be dynamically bound (e.g., `withTrailingIcon={search !== ''}`) to ensure proper layout updates. Additionally, when using Svelte reactive statements to filter lists based on search input, failing to explicitly handle the empty state (via an `else` block) leaves the list permanently filtered even after the search is cleared.
+**Action:** Always dynamically bind `withTrailingIcon` to the same condition used to render the trailing icon, and ensure reactive filtering logic includes an explicit fallback to reset state when inputs become empty.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -37,9 +39,7 @@
 		const trimmedDomain = domain.trim().toLowerCase();
 		const trimmedSearch = search.trim().toLowerCase();
 
-		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
-			return true;
-		else false;
+		return trimmedDomain.includes(trimmedSearch);
 	}
 </script>
 
@@ -52,17 +52,19 @@
 				<h4 class="domains">Domains</h4>
 				<Textfield
 					class="my-1 search-bar"
-					label="Search"
+					label="Search domains"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 **What**:
- Modified `src/routes/profile/+page.svelte` to dynamically render the "clear search" trailing icon inside the search domain input. The `withTrailingIcon` attribute is dynamically bound so it matches the icon state.
- Fixed an issue where the domain list didn't revert back to its unfiltered state when the search string became empty.
- Updated the search input's placeholder to "Search domains" and its clear button ARIA label.
- Refactored fuzzy matching to correctly handle direct substring matching.

🎯 **Why**:
- Previously, the clear icon was focusable and interactive even when the field was empty, leading to confusing keyboard navigation.
- Filtering didn't correctly recover when users manually deleted their input via keyboard backspace without clicking the button, getting stuck on the last matching state.

♿ **Accessibility**:
- The "clear search" button now only enters tab-order when it has a purpose, and announces itself contextually to screen readers as "clear search" instead of the generic "cancel".

---
*PR created automatically by Jules for task [1555935939532254920](https://jules.google.com/task/1555935939532254920) started by @yeboster*