### PR TITLE
🎨 Palette: [UX improvement] Clear search icon accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,8 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+
+## 2025-01-22 - Hide and Disabling Empty Textfield Icons
+
+**Learning:** When conditionally rendering a trailing icon inside an SMUI Textfield component (e.g. a clear search button), failing to dynamically adjust `withTrailingIcon` can leave the button visually apparent and incorrectly focusable even when its text input relies on empty state. Additionally using a generic "cancel" aria-label does not accurately describe the clear search intent.
+**Action:** Always conditionally render the icon element (e.g., `{#if search !== ''}`) and dynamically bind the `withTrailingIcon` property to the same condition so it is not focusable and the layout updates correctly. Also, replace generic labels with a descriptive `aria-label` like "clear search".

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 **What:** The UX enhancement updates the clear search icon visibility to correctly hide it from UI flow and focusability by mounting conditionally. Updates aria-label as well. Additionally fixes bug where `domainsFiltered` failed to reset correctly to full list when search gets cleared.
🎯 **Why:** To prevent keyboard users from focusing on a clear element when the input is empty and to properly describe the intent of the clear button using a better screen reader label. It also ensures the list accurately reflects the empty search query by clearing filtered results.
📸 **Before/After:** No major visual change except icon missing when empty, behavior is identical visually to previous implementation when query is empty.
♿ **Accessibility:** Replaced generic "cancel" aria label with "clear search" and prevented empty state button from taking sequential focus.

---
*PR created automatically by Jules for task [18212447946506248805](https://jules.google.com/task/18212447946506248805) started by @yeboster*