### PR TITLE
🎨 Palette: Trailing Search Icon Accessibility & State Reset

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,9 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.
+
+## 2024-10-25 - Trailing Icons Accessibility & Conditional Rendering
+
+**Learning:** When using trailing icons (e.g. for a "clear search" button) within Textfield components, rendering the icon unconditionally even when the input is empty causes it to be focusable and confusing to screen readers, especially if it performs no action.
+**Action:** Conditionally render the trailing icon block and dynamically bind `withTrailingIcon` to the same condition (e.g. `search !== ''`), ensuring keyboard accessibility and proper alignment. Furthermore, update `aria-label` to be descriptive (e.g. "clear search" instead of "cancel").

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -37,9 +39,10 @@
 		const trimmedDomain = domain.trim().toLowerCase();
 		const trimmedSearch = search.trim().toLowerCase();
 
-		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
+		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch)) {
 			return true;
-		else false;
+		}
+		return false;
 	}
 </script>
 
@@ -55,14 +58,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon" tabindex="-1">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 What: Conditionally render the trailing search "clear" icon, updating its layout binding, providing a proper ARIA label, and resolving a logic bug where clearing the search field didn't reset the domain list.
🎯 Why: Without conditional rendering, the invisible icon remained focusable and readable to screen readers. If it does not perform an action, it should not exist. Also fixed a functional bug causing list states not to return to normal when clearing the field.
📸 Before/After: Visual presentation stays identical, but the `tab` key will no longer highlight empty trailing space, screen readers will announce "clear search" when populated instead of "cancel", and the domain list will instantly repopulate when clearing the field.
♿ Accessibility: Better screen reader labels and proper hiding/showing of focusable buttons.

---
*PR created automatically by Jules for task [31038399437059562](https://jules.google.com/task/31038399437059562) started by @yeboster*