### PR TITLE
🎨 Palette: Improve clear search UX and accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.
+## 2024-10-24 - Conditionally render clear button and improve aria-label
+**Learning:** Textfields with a trailing clear icon can cause issues for keyboard navigation if the clear button is focusable while the input is empty. Additionally, "cancel" is too generic for an action that simply clears a search field.
+**Action:** Always conditionally render clear icons (`{#if search !== ''}`) and bind the `withTrailingIcon` property to the same condition. Also, ensure the `aria-label` is descriptive, like "clear search".

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -37,9 +37,7 @@
 		const trimmedDomain = domain.trim().toLowerCase();
 		const trimmedSearch = search.trim().toLowerCase();
 
-		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
-			return true;
-		else false;
+		return trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch);
 	}
 </script>
 
@@ -55,14 +53,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
**💡 What:** 
Improved the UX and accessibility of the domain search input field on the profile page. The "clear search" icon button now only renders when there is actual text to clear. Furthermore, the `aria-label` for the clear button was changed from a generic "cancel" to a descriptive "clear search".

**🎯 Why:**
Previously, the clear button (with a generic "cancel" label) was always rendered in the DOM, meaning keyboard users tabbing through the interface could focus it even when the search field was empty (making the clear action pointless). A descriptive label also vastly improves the experience for screen reader users.

**📸 Before/After:**
- *Before:* The textfield had a hardcoded `withTrailingIcon` attribute, rendering an icon button with `aria-label="cancel"` at all times.
- *After:* The `withTrailingIcon` property is bound dynamically (`search !== ''`), and the button `{#if search !== ''}` wrapper prevents empty-state focus and renders an `aria-label="clear search"`.

**♿ Accessibility:**
- Removed an unnecessary focusable element from the tab order when inactive.
- Replaced a vague screen reader announcement ("cancel") with a direct, context-aware one ("clear search").

---
*PR created automatically by Jules for task [4257432059547891651](https://jules.google.com/task/4257432059547891651) started by @yeboster*