### PR TITLE
🎨 Palette: Improve Profile Search Input UX and Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+
+## 2024-10-25 - Search Input Reset and Focus Accessibility
+**Learning:** Reactive filters in Svelte need an explicit fallback (e.g., `else`) to clear state when an input empties. Additionally, trailing icons (like a 'clear search' button) in `Textfield` components should be conditionally rendered and their wrapper bound dynamically (`withTrailingIcon={search !== ''}`) so they don't incorrectly receive focus or announce poorly to screen readers when no text is present.
+**Action:** Add default fallback states for reactive filtered data. Wrap clear/trailing icons in `{#if value !== ''}` and assign meaningful `aria-label`s like 'clear search' instead of 'cancel'.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 **What:**
- Added default fallback states for reactive filtered data when the search input is cleared.
- Conditionally render the trailing "clear" icon button.
- Updated `aria-label` to "clear search".

🎯 **Why:**
- Previously, if the user cleared the search input via keyboard, the filtered list would not reset back to the full domain list.
- An empty search box still had a focusable "cancel" button, which could be confusing for keyboard navigation and screen readers.

📸 **Before/After:**
*(Visual changes mainly involve the disappearance of the trailing icon when the input is empty.)*

♿ **Accessibility:**
- The trailing icon is no longer incorrectly focusable when there is no text to clear.
- The button is announced meaningfully as "clear search" rather than the generic "cancel".

---
*PR created automatically by Jules for task [6788033836339917245](https://jules.google.com/task/6788033836339917245) started by @yeboster*