### PR TITLE
🎨 Palette: Fix profile search empty state accessibility & logic

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.
+## 2024-10-24 - Trailing Icons and Search Reset
+**Learning:** In SMUI Textfields, simply passing `withTrailingIcon` and providing the slot content makes the element focusable even if functionally empty. Conditionally binding the prop (`withTrailingIcon={search !== ''}`) and wrapping the slot content in an `{#if search !== ''}` block ensures screen readers don't focus on empty, hidden controls. Additionally, reactive search filters must include an `else` branch to reset results when the input is cleared.
+**Action:** Always conditionally render both the `withTrailingIcon` prop and its slot content for optional clear buttons, and ensure reactive filter statements handle the empty state.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 **What:** 
- Hidden the "clear search" trailing icon in the domains profile search field when the input is empty.
- Added an `else` branch to the reactive search filter to correctly restore the full list of domains when the input is cleared.
- Changed the `aria-label` of the clear button from "cancel" to the more descriptive "clear search".
- Fixed a Svelte `no-unused-expressions` TS error in the filter logic.

🎯 **Why:** 
When the search input was empty, the `withTrailingIcon` property was still blindly reserving space and keeping the empty clear button focusable, confusing screen reader users. Additionally, clearing the input via backspacing failed to reset the reactive `domainsFiltered` list because it lacked a fallback branch.

♿ **Accessibility:**
Screen readers will no longer announce an invisible, generic "cancel" button when focusing through the empty search field. 

**Journal Updated:** Yes, logged learnings about Svelte reactive filter fallbacks and conditional SMUI trailing icons.

---
*PR created automatically by Jules for task [10116411385595656501](https://jules.google.com/task/10116411385595656501) started by @yeboster*