### PR TITLE
🎨 Palette: [UX improvement] enhance clear button and search reactivity on profile page

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,6 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+## 2025-02-13 - Conditional Icon Rendering for Clear Buttons
+**Learning:** In SMUI Textfields, dynamically binding `withTrailingIcon={condition}` isn't always enough for accessibility and keyboard navigation. Even if the icon is visually hidden via CSS or the library's internal logic, an empty `aria-label` button wrapper might still be focusable if it remains in the DOM. Furthermore, using a generic `aria-label="cancel"` for a search clear button is ambiguous to screen readers.
+**Action:** When implementing clearable search fields, use Svelte's `{#if ...}` to completely unmount the trailing icon wrapper from the DOM when the field is empty, bind the `withTrailingIcon` property to the same condition so the layout adjusts correctly, and use descriptive labels like `aria-label="clear search"`.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 What: Conditionally render the search clear icon so it doesn't appear when empty, update its `aria-label` to be more descriptive ("clear search" vs "cancel"), fix Svelte reactivity so clearing the search resets the domain list, and fix a missing return statement in the fuzzy match logic.
🎯 Why: The previous "cancel" button remained focusable when empty, and its label was not helpful for screen reader users. Additionally, clearing the text by backspacing didn't restore the original domain list, causing user confusion.
♿ Accessibility: The "clear search" button is now fully hidden from screen readers and keyboard navigation when empty, and its descriptive label correctly states its purpose.

---
*PR created automatically by Jules for task [4201140902563764641](https://jules.google.com/task/4201140902563764641) started by @yeboster*