### PR TITLE
🎨 Palette: Improve search input UX and list reset behavior

### DIFF
--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 What: Added an `else` fallback to the domains filtering reactive statement and bound the trailing clear icon to conditionally render and apply `withTrailingIcon` dynamically on the SMUI Textfield.
🎯 Why: If a user types into the search input and then clears it, the filtered list would not reset. Furthermore, unconditionally rendering the trailing icon slot on SMUI Textfield causes layout inconsistencies, and screen readers may pick up focusable invisible elements.
📸 Before/After: Visual padding behaves consistently, and clear icon correctly disappears when empty.
♿ Accessibility: Changed the clear button's `aria-label` from generic `cancel` to `clear search`, and dynamically hid it when the input is empty to avoid inaccessible ghost focus states.

---
*PR created automatically by Jules for task [5645723486308396451](https://jules.google.com/task/5645723486308396451) started by @yeboster*