### PR TITLE
⚡ Bolt: [performance improvement] cache valid coins config to Set

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,8 @@
 
 **Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
 **Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.
+
+## 2024-11-20 - Redundant Static Config Parsing
+
+**Learning:** Parsing static SDK configuration arrays (like valid coins) inside SvelteKit request handlers adds redundant latency via repeated O(N) `.includes()` lookups on every single request.
+**Action:** Extract and transform static configurations to O(1) data structures (like `Set`) at the module level to skip repeated processing overhead during request execution.

--- a/src/routes/api/register/[name]/fees/[coin]/+server.ts
+++ b/src/routes/api/register/[name]/fees/[coin]/+server.ts
@@ -3,10 +3,11 @@ import type { BYOCSymbol } from '@metanames/sdk';
 import { json } from '@sveltejs/kit';
 import type { DomainFeesResponse } from 'src/lib/types';
 
+const validCoins = new Set(metaNamesSdk.config.byoc.map((byoc) => byoc.symbol.toString()));
+
 export async function GET({ params: { name, coin } }) {
 	return handleError(async () => {
-		const validCoins = metaNamesSdk.config.byoc.map((byoc) => byoc.symbol.toString());
-		if (!validCoins.includes(coin)) return apiError('Invalid coin');
+		if (!validCoins.has(coin)) return apiError('Invalid coin');
 
 		const normalizedDomain = metaNamesSdk.domainRepository.domainValidator.normalize(name);
 		const domainFees = await metaNamesSdk.domainRepository.calculateMintFees(


### PR DESCRIPTION
### 💡 What
Modified `src/routes/api/register/[name]/fees/[coin]/+server.ts` to construct the `validCoins` array mapping into a `Set` at the module level rather than inside the `GET` handler.

### 🎯 Why
Previously, the endpoint would map `metaNamesSdk.config.byoc` to an array of string symbols and perform an O(N) `.includes(coin)` array lookup on **every single request**. Since the SDK configuration is entirely static, this was a redundant operation wasting CPU cycles on a highly accessed route.

### 📊 Impact
* **Reduces CPU overhead:** Maps the configuration array exactly once during module initialization instead of N times.
* **Improves latency:** Validates coins using an O(1) `.has()` Set lookup instead of an O(N) `.includes()` Array lookup.
* **Reduces GC pressure:** Avoids generating temporary mapped arrays on every request.

### 🔬 Measurement
Run `pnpm run test:unit --run` to verify that no functional regressions have occurred and formatting passes via `pnpm lint`. The optimization relies entirely on module caching rather than functional behavior changes, guaranteeing identical outputs.

---
*PR created automatically by Jules for task [1126689968640287085](https://jules.google.com/task/1126689968640287085) started by @yeboster*