### PR TITLE
🎨 Palette: [UX improvement] Enhance domain search input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,6 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+## 2024-10-24 - Search Input State and Conditional Icons
+**Learning:** Reactive search filters must explicitly handle the empty state (via an `else` block) to reset results when the user clears the input. Additionally, conditionally rendered trailing icons in SMUI Textfields must dynamically bind `withTrailingIcon={condition}` and only render the icon element when the condition is true to prevent empty focusable elements. Using a descriptive `aria-label` like "clear search" is better than a generic "cancel".
+**Action:** Always include an explicit reset path in reactive search blocks. When conditionally showing a trailing clear button in a Textfield, bind the `withTrailingIcon` property to the same condition and wrap the slot content in an `#if` block. Use descriptive `aria-label`s.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 **What:** Improved the UX of the domain search input on the profile page.
🎯 **Why:** Previously, the clear icon button was focusable even when the search input was empty, leading to a confusing interactive element. Additionally, clearing the text using backspace did not properly reset the `domainsFiltered` state back to the original list of `domains`.
📸 **Before/After:** No major visual change initially, but the clear button icon will dynamically appear and disappear based on whether text is inputted, ensuring a cleaner empty state.
♿ **Accessibility:** Replaced the generic `"cancel"` `aria-label` with a descriptive `"clear search"` `aria-label`. The element is also now removed from the DOM when empty, removing an unnecessary focus stop for keyboard/screen reader users.

---
*PR created automatically by Jules for task [15731698642081565557](https://jules.google.com/task/15731698642081565557) started by @yeboster*