### PR TITLE
🎨 Palette: [UX improvement] Enhance Domain Search Accessibility & Behavior

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.
+## 2024-10-24 - Conditionally Rendering Trailing Icons
+
+**Learning:** When using components like SMUI's `Textfield` that conditionally display clear/cancel trailing icons based on input state, dynamically binding `withTrailingIcon` to that condition is crucial. If `withTrailingIcon` is true while the icon itself is not rendered (e.g. `{#if search !== ''}`), layout issues or empty focus states can occur. Furthermore, setting a descriptive `aria-label` (like "clear search" instead of "cancel") greatly improves accessibility for screen readers interacting with these interactive elements.
+**Action:** Always conditionally bind `withTrailingIcon` and ensure the icon itself is only rendered when necessary, providing specific and descriptive `aria-label` attributes to the buttons.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 **What:** Improved the UX and accessibility of the domain search input in the Profile page. Added a fix so that clearing the input resets the filtered list back to the full list. Conditionally rendered the trailing icon so it is not visible or focusable when the input is empty. Updated the `aria-label` on the clear button.
🎯 **Why:** Previously, the "clear" icon would always be present (and focusable), but would not do anything if the search was empty. Also, due to missing `else` logic, clearing the search query would leave the user with the filtered list instead of resetting to the full domains list. The `aria-label` "cancel" lacked context compared to "clear search".
♿ **Accessibility:** The button is no longer present in the tab order when there is nothing to clear. Screen readers will now announce "clear search" instead of a generic "cancel", providing better context.
📸 **Before/After:** The cancel icon is now hidden on empty inputs, and clearing the input successfully brings back all records.

---
*PR created automatically by Jules for task [9201109567017420721](https://jules.google.com/task/9201109567017420721) started by @yeboster*