### PR TITLE
⚡ Bolt: [performance improvement] optimize O(N²) array lookups and sorting overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,8 @@
 
 **Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
 **Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.
+
+## 2024-10-25 - O(n²) Array Searches and Sorting Overheads
+
+**Learning:** `Array.prototype.includes` inside `filter` callbacks can unknowingly create O(N*M) loops. Likewise, creating intermediate arrays inside frequent callbacks like `sort` causes unnecessary garbage collection overhead.
+**Action:** Always precompute `Set` objects for O(1) membership tests before filtering. Avoid unnecessary array destructuring or allocation inside tight loops like `Array.prototype.sort`.

--- a/src/routes/api/proposals/voters/add/+server.ts
+++ b/src/routes/api/proposals/voters/add/+server.ts
@@ -23,7 +23,8 @@ export async function GET() {
 			?.setValue()
 			.values.map((voter) => voter.addressValue().value.toString('hex')) ?? [];
 
-	const newVoters = owners.filter((owner) => !voters.includes(owner)).slice(0, 50);
+	const votersSet = new Set(voters);
+	const newVoters = owners.filter((owner) => !votersSet.has(owner)).slice(0, 50);
 	if (newVoters.length === 0) return json({ newVoters }, { status: 200 });
 
 	const votingContract = await metaNamesSdk.contractRepository.getContract({

--- a/src/routes/api/proposals/voters/remove/+server.ts
+++ b/src/routes/api/proposals/voters/remove/+server.ts
@@ -25,7 +25,8 @@ export async function GET() {
 			?.setValue()
 			.values.map((voter) => voter.addressValue().value.toString('hex')) ?? [];
 
-	const votersToRemove = voters.filter((voter) => !owners.includes(voter)).slice(0, 50);
+	const ownersSet = new Set(owners);
+	const votersToRemove = voters.filter((voter) => !ownersSet.has(voter)).slice(0, 50);
 	if (votersToRemove.length === 0) return json({ newVoters: votersToRemove }, { status: 200 });
 
 	const votingContract = await metaNamesSdk.contractRepository.getContract({

--- a/src/routes/profile/DomainsTable.svelte
+++ b/src/routes/profile/DomainsTable.svelte
@@ -29,11 +29,15 @@
 
 	function handleSort() {
 		domains.sort((a, b) => {
-			const [aVal, bVal] = [a[sort], b[sort]][
-				sortDirection === 'ascending' ? 'slice' : 'reverse'
-			]();
-			if (typeof aVal === 'string' && typeof bVal === 'string') return aVal.localeCompare(bVal);
-			return Number(aVal) - Number(bVal);
+			const aVal = a[sort];
+			const bVal = b[sort];
+			let cmp;
+			if (typeof aVal === 'string' && typeof bVal === 'string') {
+				cmp = aVal.localeCompare(bVal);
+			} else {
+				cmp = Number(aVal) - Number(bVal);
+			}
+			return sortDirection === 'ascending' ? cmp : -cmp;
 		});
 		domains = domains;
 	}


### PR DESCRIPTION
💡 What:
Replaced O(N) `Array.prototype.includes()` with O(1) `Set.prototype.has()` inside array filter operations in `api/proposals/voters/add/+server.ts` and `api/proposals/voters/remove/+server.ts`. Replaced intermediate array destructuring with direct assignment inside the custom sort callback in `src/routes/profile/DomainsTable.svelte`. Logged performance considerations in `.jules/bolt.md`.

🎯 Why:
Using `Array.prototype.includes` inside `filter` callbacks unknowingly creates O(N*M) loops. Creating intermediate arrays inside frequent callbacks like `sort` causes unnecessary garbage collection overhead and slows down sorting of lists.

📊 Impact:
Reduces array subset filtering time complexity from O(N*M) to O(N+M) avoiding CPU blocking during large dataset computations. Reduces Garbage Collection overhead when sorting domains in the UI, leading to faster response times and improved scroll performance during table reordering.

🔬 Measurement:
Run the tests. Or manually verify that Domains are sorted correctly on the Profile page.

---
*PR created automatically by Jules for task [1794932779265356320](https://jules.google.com/task/1794932779265356320) started by @yeboster*