### PR TITLE
🎨 Palette: [UX improvement] Conditional search clear button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.
+
+## 2024-10-24 - Conditional Trailing Icons in SMUI Textfield
+**Learning:** When using SMUI `Textfield` with a trailing icon (like a clear search button), if the icon conditionally renders inside the `trailingIcon` slot, the `withTrailingIcon` property must also be dynamically bound to the same condition (e.g., `withTrailingIcon={search !== ''}`). If it remains statically set to `withTrailingIcon`, the layout might not update correctly when the icon is unmounted. Furthermore, the icon itself must be conditionally rendered so it is not focusable when empty, and it should use descriptive ARIA labels (e.g., 'clear search' instead of 'cancel').
+**Action:** Always bind both the `withTrailingIcon` prop and conditionally wrap the slot contents with the same boolean condition to ensure accurate focus management and visual layout for SMUI Textfields.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -55,14 +55,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
**💡 What:** We added conditional logic to the `withTrailingIcon` property and the `trailingIcon` slot in the profile page's domain search Textfield. The clear icon now only renders when the search input actually contains text. We also updated the `aria-label` from generic `cancel` to a descriptive `clear search`.

**🎯 Why:**
When users focused inside or tabbed through the `<Textfield>` with an empty state, there was still an invisible focusable "cancel" button which lead to confusion and poor keyboard navigation. Conditionally rendering the trailing icon slot, alongside dynamically passing the boolean property down to SMUI's component (`withTrailingIcon={search !== ''}`) guarantees correct component layout logic, while only exposing the action when there's actually a string to clear.

**♿ Accessibility:**
- Prevented keyboard users from tabbing into an invisible action button
- Updated `aria-label` from "cancel" to a significantly more specific "clear search" for screen-reader users.

---
*PR created automatically by Jules for task [16118814797035948528](https://jules.google.com/task/16118814797035948528) started by @yeboster*