### PR TITLE
🎨 Palette: [UX improvement] Improve search field UX and filter logic on profile page

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,6 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+## 2024-10-25 - Conditionally Rendered Trailing Icons in Textfields
+**Learning:** Conditionally rendering just the icon inside a trailing icon slot still leaves the trailing icon button focusable and taking up space when empty.
+**Action:** Ensure the entire trailing icon fragment/element is conditionally rendered and the `withTrailingIcon` property is bound to the same condition.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
**💡 What:** 
- Made the clear search trailing icon on the profile page conditional, preventing it from taking up space and being focusable when the input is empty.
- Fixed the search filtering logic so that the domain list is reset when the input is manually cleared.

**🎯 Why:**
- Trailing icons inside input fields can unnecessarily capture focus even when they have no function.
- Filtering lists via reactive inputs can get stuck in a filtered state if there's no fallback condition for an empty input.

**♿ Accessibility:**
- Updated the clear search button's aria-label from `"cancel"` to a much more descriptive `"clear search"`.
- Removed focusable clear search button when empty.

---
*PR created automatically by Jules for task [2919968017234921029](https://jules.google.com/task/2919968017234921029) started by @yeboster*