### PR TITLE
🎨 Palette: Conditional trailing icon in Profile search

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+## 2024-11-20 - Ensure trailing clear icon buttons correctly hide for empty fields and resets reactive lists
+
+**Learning:** When using reactive lists in Svelte filtering based on text inputs (like an autocomplete search string binding logic), the user may get stuck if the search is empty but the bound list is not reset or when the clear icon button is clicked. Moreover, unconditionally rendering trailing "clear search" icons in an empty text field breaks keyboard accessibility as the icon still receives focus without having an action or state to revert.
+**Action:** Always conditionally render both the HTML elements representing the trailing icons (e.g. `{#if search !== ''}`) and set dynamic boolean props on parent inputs (e.g. `withTrailingIcon={search !== ''}`). When setting up reactive statements targeting input strings, guarantee that the empty string edge cases reset their mapped list by writing explicitly handled fallbacks.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 **What:**
- Conditionally hides the clear search icon in the Profile domains search bar when the input is empty.
- Resets the `domainsFiltered` reactive list to the original `domains` list when the search input gets cleared.
- Updates the trailing icon's aria-label from `"cancel"` to `"clear search"` for better clarity.

🎯 **Why:**
- Without this change, keyboard users could tab to the focusable "clear search" button even when there was no search string to clear, resulting in an inaccessible ghost element state.
- When the search string was cleared, the filtered list was not correctly reset to the whole collection.

♿ **Accessibility:**
- Changed `IconButton` `aria-label` from generic `"cancel"` to a descriptive `"clear search"`.
- Hidden elements from the tab order when input is empty.

---
*PR created automatically by Jules for task [8700421162489458780](https://jules.google.com/task/8700421162489458780) started by @yeboster*