### PR TITLE
🎨 Palette: [UX improvement] - Profile search accessibility and filter bug fix

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.
+
+## 2024-11-05 - Conditionally rendering and labeling clear buttons in inputs
+**Learning:** Always conditionally render trailing clear icons in text fields (e.g., `{#if search !== ''}`) so they don't receive keyboard focus when the input is already empty. Also dynamically bind the `withTrailingIcon` property so layout stays consistent, and replace generic 'cancel' aria-labels with specific ones like 'clear search' to give screen reader users context.
+**Action:** Apply conditional rendering to the trailing icon fragment, bind `withTrailingIcon` dynamically, and use a descriptive `aria-label`.

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,5 @@ node_modules
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+.jules/
+static/

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 **What**: 
1. Conditionally renders the clear icon in the domain search `Textfield` so it only appears when there's text to clear.
2. Fixes a bug in the reactive search filter that prevented the domain list from resetting when the search input was cleared.
3. Adds `.jules/` and `static/` to `.prettierignore` to prevent auto-formatting failures on generated files.

🎯 **Why**: 
1. Empty clear buttons shouldn't receive keyboard focus as it causes unnecessary tab stops for keyboard navigation.
2. The domain list failed to show all domains again once the user deleted their search query, frustrating users.
3. The codebase `pnpm run format` command was failing because it attempted to format newly generated `.jules/palette.md` and compiled `static/` fonts.

📸 **Before/After**: Visual change is minor (clear icon disappears when input is empty).

♿ **Accessibility**: 
* Replaced the generic `aria-label="cancel"` with a more contextually accurate `aria-label="clear search"` for screen reader users.
* Empty icon container is removed from the DOM so it cannot receive keyboard focus, reducing tab fatigue.

---
*PR created automatically by Jules for task [16019892818908916410](https://jules.google.com/task/16019892818908916410) started by @yeboster*