### PR TITLE
⚡ Bolt: [performance improvement] Array Filtering O(N*M) Set Optmization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 
 **Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
 **Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.
+
+## 2026-06-27 - O(N*M) Array Filtering and Static Mappings
+**Learning:** Using `Array.prototype.includes()` inside `Array.prototype.filter()` introduces O(N*M) complexity which is detrimental for large datasets (e.g. comparing `owners` against `voters`). Additionally, static configurations like `metaNamesSdk.config.byoc` should be mapped at the module level rather than on every request.
+**Action:** Precompute an O(1) `Set` before filtering to optimize array comparisons to O(N). Move static module configurations to module-level sets or constants.

--- a/src/routes/api/proposals/voters/add/+server.ts
+++ b/src/routes/api/proposals/voters/add/+server.ts
@@ -22,8 +22,10 @@ export async function GET() {
 			.get('voters')
 			?.setValue()
 			.values.map((voter) => voter.addressValue().value.toString('hex')) ?? [];
+	const votersSet = new Set(voters);
 
-	const newVoters = owners.filter((owner) => !voters.includes(owner)).slice(0, 50);
+	// Optimizing O(N*M) inclusion check to O(N) Set lookup
+	const newVoters = owners.filter((owner) => !votersSet.has(owner)).slice(0, 50);
 	if (newVoters.length === 0) return json({ newVoters }, { status: 200 });
 
 	const votingContract = await metaNamesSdk.contractRepository.getContract({

--- a/src/routes/api/proposals/voters/remove/+server.ts
+++ b/src/routes/api/proposals/voters/remove/+server.ts
@@ -19,13 +19,15 @@ export async function GET() {
 		return json({ error: 'Voting has ended' }, { status: 400 });
 
 	const owners = await metaNamesSdk.domainRepository.getOwners();
+	const ownersSet = new Set(owners);
 	const voters =
 		fields
 			.get('voters')
 			?.setValue()
 			.values.map((voter) => voter.addressValue().value.toString('hex')) ?? [];
 
-	const votersToRemove = voters.filter((voter) => !owners.includes(voter)).slice(0, 50);
+	// Optimizing O(N*M) inclusion check to O(N) Set lookup
+	const votersToRemove = voters.filter((voter) => !ownersSet.has(voter)).slice(0, 50);
 	if (votersToRemove.length === 0) return json({ newVoters: votersToRemove }, { status: 200 });
 
 	const votingContract = await metaNamesSdk.contractRepository.getContract({

--- a/src/routes/api/register/[name]/fees/[coin]/+server.ts
+++ b/src/routes/api/register/[name]/fees/[coin]/+server.ts
@@ -1,12 +1,13 @@
 import { apiError, handleError, metaNamesSdk } from '$lib/server';
 import type { BYOCSymbol } from '@metanames/sdk';
 import { json } from '@sveltejs/kit';
-import type { DomainFeesResponse } from 'src/lib/types';
+
+// Precomputing the valid coins at module level to avoid recalculation per request
+const validCoinsSet = new Set(metaNamesSdk.config.byoc.map((byoc) => byoc.symbol.toString()));
 
 export async function GET({ params: { name, coin } }) {
 	return handleError(async () => {
-		const validCoins = metaNamesSdk.config.byoc.map((byoc) => byoc.symbol.toString());
-		if (!validCoins.includes(coin)) return apiError('Invalid coin');
+		if (!validCoinsSet.has(coin)) return apiError('Invalid coin');
 
 		const normalizedDomain = metaNamesSdk.domainRepository.domainValidator.normalize(name);
 		const domainFees = await metaNamesSdk.domainRepository.calculateMintFees(


### PR DESCRIPTION
**💡 What**:
- Replaced `Array.prototype.includes` checks within `filter` with `Set.prototype.has` lookups for large API data structures in voter `add` and `remove` functions.
- Precomputed `metaNamesSdk.config.byoc` validation mapping into a module-level `Set` in the domain fees API.

**🎯 Why**:
Using `.includes()` inside `.filter()` introduces an O(N*M) time complexity loop pattern which degrades exponentially with array sizes, specifically when comparing potentially large `owners` datasets against `voters` lists. Recalculating static values per endpoint call redundantly wastes compute.

**📊 Impact**:
- Reduces filtering complexity from O(N*M) to O(N+M) for voter processing endpoints, speeding up execution significantly for large datasets.
- Reduces repetitive configuration mapping time per request to `O(1)` constant lookups in the domains API.

**🔬 Measurement**:
Run API unit and integration tests to confirm the optimized endpoints function correctly and uniformly relative to their original definitions. Wait times on these endpoints under high load with large datasets will be empirically reduced.

---
*PR created automatically by Jules for task [17356591773687273091](https://jules.google.com/task/17356591773687273091) started by @yeboster*