### PR TITLE
⚡ Bolt: [performance improvement] Precompute valid coins Set for API

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,8 @@
 
 **Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
 **Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.
+
+## 2024-10-25 - Static configuration caching
+
+**Learning:** In request handlers like `GET` in SvelteKit `+server.ts` files, deriving values from static configurations (like `metaNamesSdk.config.byoc.map`) on every request causes unnecessary overhead.
+**Action:** Move static mapping logic out of the request handler and compute it once at module initialization, preferably storing it in a `Set` for O(1) lookup.

--- a/src/routes/api/register/[name]/fees/[coin]/+server.ts
+++ b/src/routes/api/register/[name]/fees/[coin]/+server.ts
@@ -3,10 +3,12 @@ import type { BYOCSymbol } from '@metanames/sdk';
 import { json } from '@sveltejs/kit';
 import type { DomainFeesResponse } from 'src/lib/types';
 
+// Precompute valid coins as a Set for O(1) lookups and avoid redundant map on every request
+const validCoins = new Set(metaNamesSdk.config.byoc.map((byoc) => byoc.symbol.toString()));
+
 export async function GET({ params: { name, coin } }) {
 	return handleError(async () => {
-		const validCoins = metaNamesSdk.config.byoc.map((byoc) => byoc.symbol.toString());
-		if (!validCoins.includes(coin)) return apiError('Invalid coin');
+		if (!validCoins.has(coin)) return apiError('Invalid coin');
 
 		const normalizedDomain = metaNamesSdk.domainRepository.domainValidator.normalize(name);
 		const domainFees = await metaNamesSdk.domainRepository.calculateMintFees(


### PR DESCRIPTION
💡 **What**: The optimization moves the mapping of `validCoins` (`metaNamesSdk.config.byoc.map`) outside of the `GET` request handler in `src/routes/api/register/[name]/fees/[coin]/+server.ts` and converts the resulting array into a `Set`.
🎯 **Why**: Previously, the API would evaluate the static configuration array, allocate a new mapped array, and run an O(N) `.includes()` linear scan on every single incoming GET request. This was unnecessary overhead for static configurations.
📊 **Impact**: Changes the inclusion check from O(N) to O(1) and eliminates redundant mapping computations on every API request.
🔬 **Measurement**: Verified via standard unit tests and local Git diff inspection to ensure it resolves safely in constant time.

---
*PR created automatically by Jules for task [14677475422724281215](https://jules.google.com/task/14677475422724281215) started by @yeboster*