### PR TITLE
🎨 Palette: [UX improvement]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+
+## 2024-11-06 - Accessible Trailing Icons in SMUI Textfields
+**Learning:** Trailing icons in input fields (like clear buttons) should be conditionally rendered to prevent users from focusing on an empty action. Furthermore, dynamically binding `withTrailingIcon` to the same condition ensures layout consistency in SMUI components.
+**Action:** Always conditionally render trailing interactive elements in input fields based on the input's value and use descriptive `aria-label`s instead of generic ones like "cancel".

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -39,7 +39,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +55,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
**💡 What:** I conditionally rendered the "clear search" trailing icon in the domain search `Textfield` so that it only appears and takes up space when the user actually types something. I also updated its aria-label from a generic "cancel" to a descriptive "clear search".
**🎯 Why:** Currently, the close icon is always rendered, meaning users tabbing through the interface can focus on it and attempt to clear an empty search field, which is a confusing and slightly broken experience.
**📸 Before/After:** Before: Cancel icon is visibly interactive on empty state. After: Clean search field until input.
**♿ Accessibility:** I removed an empty focus trap (actionable button with no purpose) and updated the `aria-label` to properly describe the button's action. I also updated the `withTrailingIcon` attribute dynamically to maintain SMUI's layout boundaries.

---
*PR created automatically by Jules for task [18084020956277354914](https://jules.google.com/task/18084020956277354914) started by @yeboster*