### PR TITLE
⚡ Bolt: [performance improvement] Eliminate GC overhead in domain sorting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 
 **Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
 **Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.
+
+## 2025-02-24 - Sorting Garbage Collection Overhead
+**Learning:** Creating temporary arrays inside an `Array.prototype.sort()` callback (e.g., `[a, b][condition ? 'slice' : 'reverse']()`) generates massive garbage collection overhead since the array is re-allocated for every single comparison.
+**Action:** Refactor sorting logic to use straightforward scalar variable assignments and mathematical negations for descending order.

--- a/src/routes/profile/DomainsTable.svelte
+++ b/src/routes/profile/DomainsTable.svelte
@@ -29,11 +29,18 @@
 
 	function handleSort() {
 		domains.sort((a, b) => {
-			const [aVal, bVal] = [a[sort], b[sort]][
-				sortDirection === 'ascending' ? 'slice' : 'reverse'
-			]();
-			if (typeof aVal === 'string' && typeof bVal === 'string') return aVal.localeCompare(bVal);
-			return Number(aVal) - Number(bVal);
+			// ⚡ Bolt: Use scalar assignment to avoid temporary array allocation (GC overhead) in every comparison
+			const aVal = a[sort];
+			const bVal = b[sort];
+			let comparison = 0;
+
+			if (typeof aVal === 'string' && typeof bVal === 'string') {
+				comparison = aVal.localeCompare(bVal);
+			} else {
+				comparison = Number(aVal) - Number(bVal);
+			}
+
+			return sortDirection === 'ascending' ? comparison : -comparison;
 		});
 		domains = domains;
 	}


### PR DESCRIPTION
- **What**: Refactored `handleSort` in `DomainsTable.svelte` to use scalar variable assignments instead of creating and slicing temporary arrays for every comparison.
- **Why**: The previous implementation `[a, b][condition ? 'slice' : 'reverse']()` allocated a new array and called an array method on every single sort comparison, causing significant garbage collection (GC) overhead when sorting many domains.
- **Impact**: Reduces GC pauses and speeds up sorting operations from O(N log N) allocations to zero extra allocations per sort.
- **Measurement**: Measure the rendering performance and JS heap size in the Chrome DevTools Performance tab when sorting a table with hundreds of domains.

---
*PR created automatically by Jules for task [12748209862062546151](https://jules.google.com/task/12748209862062546151) started by @yeboster*