### PR TITLE
🎨 Palette: Conditionally render search clear icon and fix filter reset

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+
+## 2024-10-24 - Conditional Trailing Icons for Accessibility
+**Learning:** When using trailing icons in text fields (like a clear button), the icon remains focusable by keyboard even when it is visually unnecessary (e.g. empty input). Also, binding the `withTrailingIcon` property to a condition is necessary for proper layout updates.
+**Action:** Always conditionally render trailing icons (e.g., `{#if search !== ''}`) so they are not focusable when irrelevant. Also bind `withTrailingIcon` to the same condition and use descriptive aria-labels (e.g. 'clear search').

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,8 @@ node_modules
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+
+.Jules/
+.jules/
+static/
+test-results/

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
💡 **What:** 
- Updated the search `Textfield` in `src/routes/profile/+page.svelte` to conditionally render its trailing 'clear' icon only when there is text in the search input.
- Changed the icon button's `aria-label` from "cancel" to "clear search".
- Fixed a bug where clearing the search field (e.g., via backspace) did not reset the `domainsFiltered` array back to the full list of domains.

🎯 **Why:** 
Previously, the clear button was always present in the DOM. Even if the search input was empty (meaning there was nothing to clear), the button could still be reached via keyboard navigation (tabbing), which is confusing for screen reader users and keyboard navigators. Additionally, the label "cancel" is ambiguous; "clear search" explicitly states the button's purpose. Finally, clearing the search input via keyboard backspaces left the filtered list stuck on the results of the last typed character, preventing users from easily viewing all their domains without refreshing.

♿ **Accessibility:**
- The clear button is now removed from the focus order when the input is empty.
- The `aria-label` is much more descriptive ("clear search" vs "cancel").
- The DOM updates properly because `withTrailingIcon` is bound to the same condition.

---
*PR created automatically by Jules for task [8164934079318432726](https://jules.google.com/task/8164934079318432726) started by @yeboster*