### PR TITLE
🎨 Palette: [UX improvement] Improve search field clear button interaction

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 
 **Learning:** Async buttons that handle errors often fail to reset their error state on subsequent attempts. This leads to a confusing UX where a successful retry still displays the error icon, making the user believe the action failed again.
 **Action:** Always ensure that error flags (e.g., `hasError`) are reset at the _start_ of the async operation, not just set in the `catch` block.
+
+## 2024-10-25 - Conditional Trailing Icons in SMUI Textfields
+**Learning:** Trailing icons (like clear buttons) inside SMUI `Textfield` components remain focusable and take up layout space even when they shouldn't be active (e.g., when a search input is empty).
+**Action:** Conditionally render the icon element (e.g., `{#if search !== ''}`) to remove it from the focus order and dynamically bind the `withTrailingIcon` property to the same condition so the layout updates correctly. Use descriptive `aria-label`s like "clear search" instead of generic names.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -17,6 +17,8 @@
 
 	$: if (search !== '') {
 		domainsFiltered = domains.filter((domain) => isFuzzyMatch(domain.name, search));
+	} else {
+		domainsFiltered = domains;
 	}
 
 	walletAddress.subscribe(async (address) => {
@@ -39,7 +41,7 @@
 
 		if (trimmedDomain.startsWith(trimmedSearch) || trimmedDomain.includes(trimmedSearch))
 			return true;
-		else false;
+		else return false;
 	}
 </script>
 
@@ -55,14 +57,16 @@
 					label="Search"
 					bind:value={search}
 					variant="outlined"
-					withTrailingIcon
+					withTrailingIcon={search !== ''}
 				>
 					<svelte:fragment slot="trailingIcon">
-						<div class="close-icon">
-							<IconButton on:click={cleanSearch} aria-label="cancel">
-								<Icon icon="cancel" />
-							</IconButton>
-						</div>
+						{#if search !== ''}
+							<div class="close-icon">
+								<IconButton on:click={cleanSearch} aria-label="clear search">
+									<Icon icon="cancel" />
+								</IconButton>
+							</div>
+						{/if}
 					</svelte:fragment>
 				</Textfield>
 				<DomainsTable domains={domainsFiltered} {loaded} />


### PR DESCRIPTION
* **What**: Made the clear button in the profile search field conditional (only visible when there's text) and fixed the search reset logic.
* **Why**: An always-present clear button in an empty search field is confusing, takes up unnecessary focus order space for keyboard users, and fixing the reset bug ensures the filtered domains revert to the full list properly.
* **Before/After**: The search bar no longer shows a trailing cancel icon when the input is empty.
* **Accessibility**: Added `aria-label="clear search"` to replace the generic "cancel" label for better screen reader context, and improved keyboard navigation by removing an inactive button from the focus order.

---
*PR created automatically by Jules for task [6277067549779336164](https://jules.google.com/task/6277067549779336164) started by @yeboster*