### PR TITLE
⚡ Bolt: [performance improvement] Convert O(N*M) array filtering to O(N) with Set lookups

### DIFF
--- a/src/routes/api/proposals/voters/add/+server.ts
+++ b/src/routes/api/proposals/voters/add/+server.ts
@@ -23,7 +23,9 @@ export async function GET() {
 			?.setValue()
 			.values.map((voter) => voter.addressValue().value.toString('hex')) ?? [];
 
-	const newVoters = owners.filter((owner) => !voters.includes(owner)).slice(0, 50);
+	// ⚡ Bolt: Use Set for O(1) lookup to avoid O(N*M) complexity in large arrays
+	const votersSet = new Set(voters);
+	const newVoters = owners.filter((owner) => !votersSet.has(owner)).slice(0, 50);
 	if (newVoters.length === 0) return json({ newVoters }, { status: 200 });
 
 	const votingContract = await metaNamesSdk.contractRepository.getContract({

--- a/src/routes/api/proposals/voters/remove/+server.ts
+++ b/src/routes/api/proposals/voters/remove/+server.ts
@@ -25,7 +25,9 @@ export async function GET() {
 			?.setValue()
 			.values.map((voter) => voter.addressValue().value.toString('hex')) ?? [];
 
-	const votersToRemove = voters.filter((voter) => !owners.includes(voter)).slice(0, 50);
+	// ⚡ Bolt: Use Set for O(1) lookup to avoid O(N*M) complexity in large arrays
+	const ownersSet = new Set(owners);
+	const votersToRemove = voters.filter((voter) => !ownersSet.has(voter)).slice(0, 50);
 	if (votersToRemove.length === 0) return json({ newVoters: votersToRemove }, { status: 200 });
 
 	const votingContract = await metaNamesSdk.contractRepository.getContract({


### PR DESCRIPTION
💡 What: Converted O(N*M) array filtering to O(N) by replacing `Array.prototype.includes()` with `Set.prototype.has()` when finding voters to add/remove.
🎯 Why: Filtering a list of thousands of `owners` against a list of thousands of `voters` using `includes()` creates an O(N*M) bottleneck, which significantly slows down API responses and blocks the main thread.
📊 Impact: Expected ~100x performance improvement in the filtering step (e.g., reduces filtering time from ~400ms to ~4ms for 10k items).
🔬 Measurement: Run benchmark of `includes` vs `Set.has` on 10k items, or measure the TTFB (Time to First Byte) of the `/api/proposals/voters/add` endpoint before and after the change.

---
*PR created automatically by Jules for task [9277963963170897237](https://jules.google.com/task/9277963963170897237) started by @yeboster*