### PR TITLE
⚡ Bolt: [performance improvement] Replace O(N) includes with O(1) Set lookup in voter APIs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 
 **Learning:** Using `on:keyup` for search input debouncing triggers unnecessary API calls on navigation keys (arrows, home, end) and misses changes from paste/cut. Svelte's reactive statements `$: debounce(value)` provide a robust, declarative way to trigger debouncing only when the value actually changes.
 **Action:** Replace `on:keyup` handlers with reactive statements for input debouncing to improve performance and correctness.
+## 2024-11-20 - Set for O(1) Lookups in Large Array Filtering
+
+**Learning:** When filtering large lists (like `owners` against `voters`), using `Array.prototype.includes()` inside `.filter()` results in an O(N*M) complexity. This causes significant performance degradation as both lists grow.
+**Action:** Always precompute a `Set` before the filter loop to convert the O(N) array lookup into an O(1) set lookup, improving the overall complexity to O(N).

--- a/src/routes/api/proposals/voters/add/+server.ts
+++ b/src/routes/api/proposals/voters/add/+server.ts
@@ -23,7 +23,10 @@ export async function GET() {
 			?.setValue()
 			.values.map((voter) => voter.addressValue().value.toString('hex')) ?? [];
 
-	const newVoters = owners.filter((owner) => !voters.includes(owner)).slice(0, 50);
+	// ⚡ Bolt Performance Optimization
+	// Use Set for O(1) lookups instead of O(N) Array.includes to avoid O(N*M) complexity
+	const votersSet = new Set(voters);
+	const newVoters = owners.filter((owner) => !votersSet.has(owner)).slice(0, 50);
 	if (newVoters.length === 0) return json({ newVoters }, { status: 200 });
 
 	const votingContract = await metaNamesSdk.contractRepository.getContract({

--- a/src/routes/api/proposals/voters/remove/+server.ts
+++ b/src/routes/api/proposals/voters/remove/+server.ts
@@ -25,7 +25,10 @@ export async function GET() {
 			?.setValue()
 			.values.map((voter) => voter.addressValue().value.toString('hex')) ?? [];
 
-	const votersToRemove = voters.filter((voter) => !owners.includes(voter)).slice(0, 50);
+	// ⚡ Bolt Performance Optimization
+	// Use Set for O(1) lookups instead of O(N) Array.includes to avoid O(N*M) complexity
+	const ownersSet = new Set(owners);
+	const votersToRemove = voters.filter((voter) => !ownersSet.has(voter)).slice(0, 50);
 	if (votersToRemove.length === 0) return json({ newVoters: votersToRemove }, { status: 200 });
 
 	const votingContract = await metaNamesSdk.contractRepository.getContract({


### PR DESCRIPTION
💡 What: Replaced `Array.prototype.includes()` inside array `.filter()` loops with `Set.prototype.has()` in the voter addition and removal APIs (`src/routes/api/proposals/voters/add/+server.ts` and `src/routes/api/proposals/voters/remove/+server.ts`).
🎯 Why: The original implementation iterated over an array and performed an O(N) `.includes()` lookup for each element, leading to O(N*M) time complexity. As the number of domain owners and voters grows, this significantly slows down the API.
📊 Impact: Expected performance improvement changes complexity from O(N*M) to O(N+M). This drastically reduces CPU utilization and response time for large datasets.
🔬 Measurement: Verify by executing the unit tests (`pnpm test:unit --run`) and optionally benchmarking the `/api/proposals/voters/add` and `/api/proposals/voters/remove` endpoints locally with large mocked arrays to observe the execution time reduction.

---
*PR created automatically by Jules for task [13373394845453975963](https://jules.google.com/task/13373394845453975963) started by @yeboster*