### PR TITLE
🎨 Palette: Add accessible ARIA attributes to Wallet Connect menu trigger

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,9 @@
 ## 2024-10-24 - Accessible Icon Props and Loading Button State
+
 **Learning:** Svelte wrapper components (like `Icon.svelte`) must spread `$$restProps` to allow passing accessibility attributes (e.g., `aria-label`) from parent components. Without this, icons remain inaccessible to screen readers. Also, persistent "Success" states on buttons can be confusing; auto-resetting them after a timeout improves clarity.
 **Action:** Always include `{...$$restProps}` in wrapper components and implement auto-reset logic for temporary success states in interactive elements.
+
+## 2024-11-20 - Accessible Menu Triggers
+
+**Learning:** Interactive trigger elements that open SMUI menus lack native screen reader context for their expanded state.
+**Action:** Ensure elements that trigger SMUI menus include `aria-haspopup="menu"` and bind `aria-expanded` to the state variable that tracks the menu's open status.

--- a/src/routes/WalletConnectButton.svelte
+++ b/src/routes/WalletConnectButton.svelte
@@ -97,7 +97,12 @@
 	export let connectButtonVariant: 'raised' | 'unelevated' | 'outlined' = 'raised';
 </script>
 
-<Button variant={connectButtonVariant} on:click={toggleMenu}>
+<Button
+	variant={connectButtonVariant}
+	on:click={toggleMenu}
+	aria-haspopup="menu"
+	aria-expanded={toggleOpen}
+>
 	<slot name="buttonLabel">Connect</slot>
 </Button>
 <Menu


### PR DESCRIPTION
**What:** Added `aria-haspopup="menu"` and `aria-expanded={toggleOpen}` to the Wallet Connect trigger button.
**Why:** Screen readers need context to understand that a button opens a menu and whether that menu is currently open or closed.
**Accessibility:** Improves screen reader navigation and awareness for the main wallet connection dropdown menu, ensuring it communicates its state correctly.

---
*PR created automatically by Jules for task [17177031166839352831](https://jules.google.com/task/17177031166839352831) started by @yeboster*